### PR TITLE
Support 'Replace' operations in Runbooks

### DIFF
--- a/MSMarcoEmbeddingOnlyScenario.cs
+++ b/MSMarcoEmbeddingOnlyScenario.cs
@@ -27,6 +27,11 @@ namespace VectorIndexScenarioSuite
             this.ReplaceFinalThroughput(DefaultInitialAndFinalThroughput(this.Configurations).Item2);
         }
 
+        public override async Task Run()
+        {
+            await RunScenario();
+        }
+
         private static (int, int) DefaultInitialAndFinalThroughput(IConfiguration configurations)
         {
             // default throughput for MSMarcoEmbeddingOnlyScenario

--- a/MSTuringEmbeddingOnlyStreamingScenario.cs
+++ b/MSTuringEmbeddingOnlyStreamingScenario.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
+
 namespace VectorIndexScenarioSuite
-{ 
-    internal class MSTuringEmbeddingOnlyScenario : BigANNBinaryEmbeddingOnlyScearioBase
+{
+    internal class MSTuringEmbeddingOnlyStreamingScenario : BigANNBinaryEmbeddingOnlyScearioBase
     {
         protected override string BaseDataFile => "base";
         protected override string BinaryFileExt => "fbin";
@@ -15,21 +16,26 @@ namespace VectorIndexScenarioSuite
         protected override DistanceFunction EmbeddingDistanceFunction => DistanceFunction.Euclidean;
         protected override ulong EmbeddingDimensions => 100;
         protected override int MaxPhysicalPartitionCount => 56;
-        protected override string RunName => "msturing-embeddingonly-" + guid;
+        protected override string RunName => "msturing-embeddingonly-streaming" + guid;
 
-        public MSTuringEmbeddingOnlyScenario(IConfiguration configurations) : 
+        public MSTuringEmbeddingOnlyStreamingScenario(IConfiguration configurations) : 
             base(configurations, DefaultInitialAndFinalThroughput(configurations).Item1)
         {
-        }
-
-        public override async Task Run()
-        {
-            await RunScenario();
         }
 
         public override void Setup()
         {
             this.ReplaceFinalThroughput(DefaultInitialAndFinalThroughput(this.Configurations).Item2);
+        }
+
+        public override async Task Run()
+        {
+            await RunStreamingScenario("runbooks/msturing-10M_randomreplace_runbook.yml");
+        }
+
+        public override void Stop()
+        {
+            // No Operation required.
         }
 
         private static (int, int) DefaultInitialAndFinalThroughput(IConfiguration configurations)

--- a/Program.cs
+++ b/Program.cs
@@ -68,9 +68,11 @@ namespace VectorIndexScenarioSuite
                     return new MSMarcoEmbeddingOnlyScenario(configurations);
                 case Scenarios.MSTuringEmbeddingOnly:
                     return new MSTuringEmbeddingOnlyScenario(configurations);
+                case Scenarios.MSTuringEmbeddingOnlyStreaming:
+                    return new MSTuringEmbeddingOnlyStreamingScenario(configurations);
                 case Scenarios.WikiCohereEnglishEmbeddingOnly:
                     return new WikiCohereEnglishEmbeddingOnlyScenario(configurations);
-                case Scenarios.WikiCohereEnglishEmnbeddingOnlyStreaming:
+                case Scenarios.WikiCohereEnglishEmbeddingOnlyStreaming:
                     return new WikiCohereEnglishEmbeddingOnlyStreamingScenario(configurations);
                 default:
                     throw new System.Exception($"Scenario {scenarioName} is not supported.");

--- a/Runbook.cs
+++ b/Runbook.cs
@@ -14,6 +14,18 @@ namespace VectorIndexScenarioSuite
         [YamlMember(Alias = "end")]
         public int? End { get; set; }
 
+        [YamlMember(Alias = "ids_start")]
+        public int? IdsStart { get; set; }
+
+        [YamlMember(Alias = "ids_end")]
+        public int? IdsEnd { get; set; }
+
+        [YamlMember(Alias = "tags_start")]
+        public int? TagsStart { get; set; }
+
+        [YamlMember(Alias = "tags_end")]
+        public int? TagsEnd { get; set; }
+
         [YamlMember(Alias = "operation")]
         public required string Name { get; set; }
     }

--- a/Scenarios.cs
+++ b/Scenarios.cs
@@ -4,8 +4,9 @@
     {
         MSMarcoEmbeddingOnly,
         MSTuringEmbeddingOnly,
+        MSTuringEmbeddingOnlyStreaming,
         WikiCohereEnglishEmbeddingOnly,
-        WikiCohereEnglishEmnbeddingOnlyStreaming
+        WikiCohereEnglishEmbeddingOnlyStreaming
     }
 
     internal static class ScenarioParser
@@ -18,10 +19,12 @@
                     return Scenarios.MSMarcoEmbeddingOnly;
                 case "ms-turing-embedding-only":
                     return Scenarios.MSTuringEmbeddingOnly;
+                case "ms-turing-embedding-only-streaming":
+                    return Scenarios.MSTuringEmbeddingOnlyStreaming;
                 case "wiki-cohere-english-embedding-only":
                     return Scenarios.WikiCohereEnglishEmbeddingOnly;
                 case "wiki-cohere-english-embedding-only-streaming":
-                    return Scenarios.WikiCohereEnglishEmnbeddingOnlyStreaming;
+                    return Scenarios.WikiCohereEnglishEmbeddingOnlyStreaming;
                 default:
                     throw new ArgumentException("Invalid scenario value", scenarioString);
             }

--- a/TagIdMapper.cs
+++ b/TagIdMapper.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace VectorIndexScenarioSuite
+{
+    /*
+     * This is a utility class to keep track of TagId and its corresponding VectorId.
+     * The concept of Tags and VectorIds are used in the streaming scenario defined by Big-Ann-Benchmarks below:
+     * https://github.com/harsha-simhadri/big-ann-benchmarks/tree/main/neurips23/streaming
+     */
+    internal class TagIdMapper
+    {
+        private Dictionary<Tuple<int, int>, Tuple<int, int>> tagRangeToVectorIdRange;
+
+        public TagIdMapper()
+        {
+            this.tagRangeToVectorIdRange = new Dictionary<Tuple<int, int>, Tuple<int, int>>();
+        }
+
+        public void AddTagIdMapping(int tagIdStart, int tagIdEnd, int vectorIdStart, int vectorIdEnd)
+        {
+            if(tagIdEnd <= tagIdStart || vectorIdEnd <= vectorIdStart)
+            {
+                throw new ArgumentException("Invalid range provided for TagId or VectorId.");
+            }
+
+            this.tagRangeToVectorIdRange.Add(
+                new Tuple<int, int>(tagIdStart, tagIdEnd), new Tuple<int, int>(vectorIdStart, vectorIdEnd));
+        }
+
+        public int GetVectorIdForTagId(int tagId)
+        {
+            foreach (var tagRange in this.tagRangeToVectorIdRange.Keys)
+            {
+                if (tagId >= tagRange.Item1 && tagId <= tagRange.Item2)
+                {
+                    int delta = tagId - tagRange.Item1;
+                    return this.tagRangeToVectorIdRange[tagRange].Item1 + delta;
+                }
+            }
+
+            // If no mapping found, this implies no replaces were done, so return the same tagId as vectorId.
+            return tagId;
+        }
+    }
+}

--- a/WikiCohereEnglishEmbeddingOnlyScenario.cs
+++ b/WikiCohereEnglishEmbeddingOnlyScenario.cs
@@ -16,6 +16,11 @@ namespace VectorIndexScenarioSuite
             this.ReplaceFinalThroughput(DefaultInitialAndFinalThroughput(this.Configurations).Item2);
         }
 
+        public override async Task Run()
+        {
+            await RunScenario();
+        }
+
         private static (int, int) DefaultInitialAndFinalThroughput(IConfiguration configurations)
         {
 

--- a/WikiCohereEnglishEmbeddingOnlyStreamingScenario.cs
+++ b/WikiCohereEnglishEmbeddingOnlyStreamingScenario.cs
@@ -1,16 +1,10 @@
-﻿using Microsoft.Azure.Cosmos;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 
 namespace VectorIndexScenarioSuite
 {
     internal class WikiCohereEnglishEmbeddingOnlyStreamingScenario : WikiCohereEnglishEmbeddingBase
     {
         protected override string RunName => "wiki-cohere-english-embedding-only-streaming-" + guid;
-        private const string RUNBOOK_PATH = "runbooks/wikipedia-35M_expirationtime_runbook.yaml";
-        private const string GROUND_TRUTH_FILE_PREFIX_FOR_STEP = "step";
-
-        /* This dataset comes with ground truth computed till 100 Nearest Neighbors. */
-        private const string GROUND_TRUTH_FILE_EXTENSION_FOR_STEP = ".gt100";
 
         public WikiCohereEnglishEmbeddingOnlyStreamingScenario(IConfiguration configurations) : 
             base(configurations, DefaultInitialAndFinalThroughput(configurations).Item1)
@@ -23,122 +17,7 @@ namespace VectorIndexScenarioSuite
 
         public override async Task Run()
         {
-            Runbook book = await Runbook.Parse(RUNBOOK_PATH);
-            int startOperationId = Convert.ToInt32(this.Configurations["AppSettings:scenario:streaming:startOperationId"]);
-            int stopOperationId = Convert.ToInt32(this.Configurations["AppSettings:scenario:streaming:stopOperationId"]);
-
-            bool runIngestion = Convert.ToBoolean(this.Configurations["AppSettings:scenario:runIngestion"]);
-            int totalNetVectorsToIngest = Convert.ToInt32(this.Configurations["AppSettings:scenario:streaming:totalNetVectorsToIngest"]);
-            bool runQuery = Convert.ToBoolean(this.Configurations["AppSettings:scenario:runQuery"]);
-
-            int insertSteps = 0;
-            int searchSteps = 0;
-            int deleteSteps = 0;
-            int currentVectorCount = 0;
-
-            int totalVectorsInserted = 0;
-            int totalVectorsDeleted = 0;
-            foreach (var operationIdValue in book.RunbookData.Operation)
-            {
-                int operationId = Int32.Parse(operationIdValue.Key);
-                Operation operation = operationIdValue.Value;
-
-                switch (operation.Name)
-                {
-                    case "insert":
-                    {
-                        int start = operation.Start ?? throw new MissingFieldException("Start missing for insert.");
-                        int end = operation.End ?? throw new MissingFieldException("End missing for insert.");
-                        int numVectors = (end - start);
-                        if (runIngestion && (operationId >= startOperationId))
-                        {
-                            await PerformIngestion(IngestionOperationType.Insert, start, numVectors);
-                        }
-
-                        totalVectorsInserted += numVectors;
-
-                        // Count insert step even if we skipped it as from runbook execution perspective, it was still done before.
-                        insertSteps++;
-                        break;
-                    }
-                    case "search":
-                    {  
-                        // No warmup logic added for now as this scenario is focused on recall.
-                        if (runQuery && (operationId >= startOperationId))
-                        {
-                            int totalQueryVectors = BigANNBinaryFormat.GetBinaryDataHeader(GetQueryDataPath()).Item1;
-                            for (int kI = 0; kI < K_VALS.Length; kI++)
-                            {
-                                Console.WriteLine($"Performing {totalQueryVectors} queries for Recall/RU/Latency stats for K: {K_VALS[kI]}.");
-                                await PerformQuery(false /* isWarmup */, totalQueryVectors, K_VALS[kI] /*KVal*/, GetQueryDataPath());
-                            }
-
-                            // Compute Recall
-                            bool computeRecall = Convert.ToBoolean(this.Configurations["AppSettings:scenario:computeRecall"]);
-                            if (computeRecall)
-                            {
-                                Console.WriteLine("Computing Recall.");
-                                GroundTruthValidator groundTruthValidator = new GroundTruthValidator(
-                                    GroundTruthFileType.Binary,
-                                    GetGroundTruthDataPath(operationId));
-
-                                for (int kI = 0; kI < K_VALS.Length; kI++)
-                                {
-                                    int kVal = K_VALS[kI];
-                                    float recall = groundTruthValidator.ComputeRecall(kVal, this.queryRecallResults[kVal]);
-
-                                    Console.WriteLine($"Recall for K = {kVal} is {recall}.");
-                                }
-                            }
-                        }
-
-                        // Count search step even if we skipped it as from runbook execution perspective, it was still done before.
-                        searchSteps++;
-                        break;
-                    }
-                    case "delete":
-                    {
-                        int start = operation.Start ?? throw new MissingFieldException("Start missing for delete.");
-                        int end = operation.End ?? throw new MissingFieldException("End missing for delete.");
-                        int numVectors = (end - start);
-
-                        if (runIngestion && (operationId >= startOperationId))
-                        {
-                            await PerformIngestion(IngestionOperationType.Delete, start, numVectors);
-                        }
-                        totalVectorsDeleted += numVectors;
-
-                        // Count delete step even if we skipped it as from runbook execution perspective, it was still done before.
-                        deleteSteps++;
-                        break;
-                    }
-                    default:
-                    {
-                        throw new InvalidOperationException($"Invalid operation {operation.Name} in runbook.");
-                    }
-                }
-
-                Console.WriteLine($"Executed Operation: {operation.Name} with OperationId: {operationId}");
-
-                currentVectorCount = totalVectorsInserted - totalVectorsDeleted;
-                if (currentVectorCount > totalNetVectorsToIngest || operationId > stopOperationId)
-                {
-                    Console.WriteLine($"Exiting after finishing Step {operationId}.");
-                    break;
-                }
-            }
-
-            Console.WriteLine($"Final vector count after ingestion in collection: {currentVectorCount}, total vectors to be ingested as per appSettings: {totalNetVectorsToIngest}. ");
-            int totalSteps = insertSteps + deleteSteps + searchSteps;
-            Console.WriteLine($"Executed {totalSteps} total steps with {insertSteps} insert steps, {deleteSteps} delete steps and {searchSteps} query steps.");
-        }
-
-        private string GetGroundTruthDataPath(int stepNumber)
-        {
-            string directory = this.Configurations["AppSettings:dataFilesBasePath"] ?? 
-                throw new ArgumentNullException("AppSettings:dataFilesBasePath");
-            string fileName = $"{GROUND_TRUTH_FILE_PREFIX_FOR_STEP}{stepNumber}{GROUND_TRUTH_FILE_EXTENSION_FOR_STEP}";
-            return Path.Combine(directory, fileName);
+            await RunStreamingScenario("runbooks/wikipedia-35M_expirationtime_runbook.yaml");
         }
 
         private static (int, int) DefaultInitialAndFinalThroughput(IConfiguration configurations)

--- a/dataset/ms_turing_download.ps1
+++ b/dataset/ms_turing_download.ps1
@@ -45,9 +45,9 @@ if (-not $skipDownload)
     Rename-Item -Path $temp100MPath -NewName $new100MPath
 
     azcopy copy "https://comp21storage.z5.web.core.windows.net/comp21/MSFT-TURING-ANNS/query_gt100.bin" $destinationFolder --from-to BlobLocal --check-md5 NoCheck
-    $temp1000MPath = Join-Path $destinationFolder "msturing-gt-1000M"
+    $temp1000MPath = Join-Path $destinationFolder "query_gt100.bin"
     $new1000MPath = Join-Path $destinationFolder "ground_truth_1000000000"
-    Rename-Item -Path $temp100MPath -NewName $new100MPath
+    Rename-Item -Path $temp1000MPath -NewName $new1000MPath 
 
     # Query file
     azcopy copy "https://comp21storage.z5.web.core.windows.net/comp21/MSFT-TURING-ANNS/query100K.fbin" $destinationFolder --from-to BlobLocal --check-md5 NoCheck

--- a/dataset/ms_turing_streaming_download.ps1
+++ b/dataset/ms_turing_streaming_download.ps1
@@ -1,0 +1,38 @@
+﻿# Main script
+# Please use 'ms_turing_download.ps1' to download the dataset and query file. This script is for downloading the additional ground truth files for each 'search' step in the streaming runbook. 
+param (
+    [Parameter(Mandatory=$true)]
+    [string]$destinationFolder,
+
+    [Parameter(Mandatory=$true)]
+    [string]$azcopyPath
+)
+
+if (-not $destinationFolder) {
+    Write-Error "The destination folder is required."
+    exit 1
+}
+
+if (-not $azcopyPath) {
+    Write-Error "The azcopy tool is required."
+    exit 1
+}
+
+$destinationFolder = Resolve-Path -Path $destinationFolder
+$azcopyPath = Resolve-Path -Path $azcopyPath
+$env:PATH += ";$azcopyPath"
+
+# Set the InformationPreference to Continue to ensure Write-Information logs to the console
+$InformationPreference = 'Continue'
+
+Write-Information "Starting download..."
+
+# loop from 1 to 128 for all steps defined in runbook here : https://github.com/harsha-simhadri/big-ann-benchmarks/blob/main/neurips23/streaming/random_replace_runbook.yaml
+# Note that Ground truth files are not available for all steps but only for 'Search' steps. To simplify the script, we iterate over all steps anyways and fail silently if the file is not found.
+for ($i=1; $i -le 128; $i++)
+{
+    # handle 404 error with azcopy (do not log error)
+    $outputIgnore = azcopy copy "https://comp21storage.z5.web.core.windows.net/comp21/MSFT-TURING-ANNS/random_replace_runbook.yaml/step$i.gt100" $destinationFolder --from-to BlobLocal --check-md5 NoCheck 2>&1     
+    
+    Write-Information "Done with step $i."
+}

--- a/runbooks/msturing-10M_randomreaplace_runbook.yml
+++ b/runbooks/msturing-10M_randomreaplace_runbook.yml
@@ -1,0 +1,454 @@
+﻿# This is a slightly modified version of the BigANN runbook : https://github.com/harsha-simhadri/big-ann-benchmarks/blob/main/neurips23/streaming/random_replace_runbook.yaml
+# Minor changes to the format to work more easily with the C# strong-typed deserializer
+version: 1
+scenario:
+  max_pts: 6641122
+  operations:
+    1:
+        end: 170550
+        operation: insert
+        start: 0
+    2:
+        operation: search
+    3:
+        end: 441922
+        operation: insert
+        start: 255771
+    4:
+        operation: search
+    5:
+        end: 658388
+        operation: insert
+        start: 491965
+    6:
+        operation: search
+    7:
+        end: 984005
+        operation: insert
+        start: 824781
+    8:
+        operation: search
+    9:
+        end: 1353604
+        operation: insert
+        start: 1081209
+    10:
+        operation: search
+    11:
+        end: 1778387
+        operation: insert
+        start: 1568760
+    12:
+        operation: search
+    13:
+        end: 2214835
+        operation: insert
+        start: 1959174
+    14:
+        operation: search
+    15:
+        end: 2655948
+        operation: insert
+        start: 2404186
+    16:
+        operation: search
+    17:
+        end: 2985929
+        operation: insert
+        start: 2798660
+    18:
+        operation: search
+    19:
+        end: 3367448
+        operation: insert
+        start: 3082959
+    20:
+        operation: search
+    21:
+        end: 3767906
+        operation: insert
+        start: 3480554
+    22:
+        operation: search
+    23:
+        end: 4130724
+        operation: insert
+        start: 3910930
+    24:
+        operation: search
+    25:
+        end: 4461308
+        operation: insert
+        start: 4194870
+    26:
+        operation: search
+    27:
+        end: 4839923
+        operation: insert
+        start: 4652840
+    28:
+        operation: search
+    29:
+        end: 5032089
+        operation: insert
+        start: 4872616
+    30:
+        operation: search
+    31:
+        end: 5526086
+        operation: insert
+        start: 5184725
+    32:
+        operation: search
+    33:
+        end: 5891879
+        operation: insert
+        start: 5629098
+    34:
+        operation: search
+    35:
+        end: 6218348
+        operation: insert
+        start: 6023119
+    36:
+        operation: search
+    37:
+        end: 6413108
+        operation: insert
+        start: 6292969
+    38:
+        operation: search
+    39:
+        end: 6658829
+        operation: insert
+        start: 6508987
+    40:
+        operation: search
+    41:
+        end: 6958659
+        operation: insert
+        start: 6767675
+    42:
+        operation: search
+    43:
+        end: 7234176
+        operation: insert
+        start: 7000498
+    44:
+        operation: search
+    45:
+        end: 7402476
+        operation: insert
+        start: 7263856
+    46:
+        operation: search
+    47:
+        end: 7683180
+        operation: insert
+        start: 7485517
+    48:
+        operation: search
+    49:
+        end: 8008502
+        operation: insert
+        start: 7739934
+    50:
+        operation: search
+    51:
+        end: 8334761
+        operation: insert
+        start: 8055691
+    52:
+        operation: search
+    53:
+        end: 8578113
+        operation: insert
+        start: 8381008
+    54:
+        operation: search
+    55:
+        end: 8849550
+        operation: insert
+        start: 8750107
+    56:
+        operation: search
+    57:
+        end: 9102186
+        operation: insert
+        start: 8942969
+    58:
+        operation: search
+    59:
+        end: 9466319
+        operation: insert
+        start: 9223315
+    60:
+        operation: search
+    61:
+        end: 9624181
+        operation: insert
+        start: 9508781
+    62:
+        operation: search
+    63:
+        end: 9908074
+        operation: insert
+        start: 9722747
+    64:
+        operation: search
+    65:
+        ids_end: 9970476
+        ids_start: 9908074
+        operation: replace
+        tags_end: 62402
+        tags_start: 0
+    66:
+        operation: search
+    67:
+        ids_end: 7420049
+        ids_start: 7402476
+        operation: replace
+        tags_end: 273344
+        tags_start: 255771
+    68:
+        operation: search
+    69:
+        ids_end: 8623785
+        ids_start: 8578113
+        operation: replace
+        tags_end: 537637
+        tags_start: 491965
+    70:
+        operation: search
+    71:
+        ids_end: 1867257
+        ids_start: 1778387
+        operation: replace
+        tags_end: 913651
+        tags_start: 824781
+    72:
+        operation: search
+    73:
+        ids_end: 9468584
+        ids_start: 9466319
+        operation: replace
+        tags_end: 1083474
+        tags_start: 1081209
+    74:
+        operation: search
+    75:
+        ids_end: 9171728
+        ids_start: 9102186
+        operation: replace
+        tags_end: 1638302
+        tags_start: 1568760
+    76:
+        operation: search
+    77:
+        ids_end: 449264
+        ids_start: 441922
+        operation: replace
+        tags_end: 1966516
+        tags_start: 1959174
+    78:
+        operation: search
+    79:
+        ids_end: 2326420
+        ids_start: 2214835
+        operation: replace
+        tags_end: 2515771
+        tags_start: 2404186
+    80:
+        operation: search
+    81:
+        ids_end: 3053826
+        ids_start: 2985929
+        operation: replace
+        tags_end: 2866557
+        tags_start: 2798660
+    82:
+        operation: search
+    83:
+        ids_end: 5047708
+        ids_start: 5032089
+        operation: replace
+        tags_end: 3098578
+        tags_start: 3082959
+    84:
+        operation: search
+    85:
+        ids_end: 3827125
+        ids_start: 3767906
+        operation: replace
+        tags_end: 3539773
+        tags_start: 3480554
+    86:
+        operation: search
+    87:
+        ids_end: 7722589
+        ids_start: 7683180
+        operation: replace
+        tags_end: 3950339
+        tags_start: 3910930
+    88:
+        operation: search
+    89:
+        ids_end: 2715056
+        ids_start: 2655948
+        operation: replace
+        tags_end: 4253978
+        tags_start: 4194870
+    90:
+        operation: search
+    91:
+        ids_end: 666699
+        ids_start: 658388
+        operation: replace
+        tags_end: 4661151
+        tags_start: 4652840
+    92:
+        operation: search
+    93:
+        ids_end: 6464489
+        ids_start: 6413108
+        operation: replace
+        tags_end: 4923997
+        tags_start: 4872616
+    94:
+        operation: search
+    95:
+        ids_end: 8911561
+        ids_start: 8849550
+        operation: replace
+        tags_end: 5246736
+        tags_start: 5184725
+    96:
+        operation: search
+    97:
+        ids_end: 214429
+        ids_start: 170550
+        operation: replace
+        tags_end: 5672977
+        tags_start: 5629098
+    98:
+        operation: search
+    99:
+        ids_end: 5623390
+        ids_start: 5526086
+        operation: replace
+        tags_end: 6120423
+        tags_start: 6023119
+    100:
+        operation: search
+    101:
+        ids_end: 3433790
+        ids_start: 3367448
+        operation: replace
+        tags_end: 6359311
+        tags_start: 6292969
+    102:
+        operation: search
+    103:
+        ids_end: 6757160
+        ids_start: 6658829
+        operation: replace
+        tags_end: 6607318
+        tags_start: 6508987
+    104:
+        operation: search
+    105:
+        ids_end: 4844417
+        ids_start: 4839923
+        operation: replace
+        tags_end: 6772169
+        tags_start: 6767675
+    106:
+        operation: search
+    107:
+        ids_end: 5910157
+        ids_start: 5891879
+        operation: replace
+        tags_end: 7018776
+        tags_start: 7000498
+    108:
+        operation: search
+    109:
+        ids_end: 6992439
+        ids_start: 6958659
+        operation: replace
+        tags_end: 7297636
+        tags_start: 7263856
+    110:
+        operation: search
+    111:
+        ids_end: 4537475
+        ids_start: 4461308
+        operation: replace
+        tags_end: 7561684
+        tags_start: 7485517
+    112:
+        operation: search
+    113:
+        ids_end: 4141330
+        ids_start: 4130724
+        operation: replace
+        tags_end: 7750540
+        tags_start: 7739934
+    114:
+        operation: search
+    115:
+        ids_end: 9715601
+        ids_start: 9624181
+        operation: replace
+        tags_end: 8147111
+        tags_start: 8055691
+    116:
+        operation: search
+    117:
+        ids_end: 8024912
+        ids_start: 8008502
+        operation: replace
+        tags_end: 8397418
+        tags_start: 8381008
+    118:
+        operation: search
+    119:
+        ids_end: 1453047
+        ids_start: 1353604
+        operation: replace
+        tags_end: 8849550
+        tags_start: 8750107
+    120:
+        operation: search
+    121:
+        ids_end: 1054574
+        ids_start: 984005
+        operation: replace
+        tags_end: 9013538
+        tags_start: 8942969
+    122:
+        operation: search
+    123:
+        ids_end: 8375611
+        ids_start: 8334761
+        operation: replace
+        tags_end: 9264165
+        tags_start: 9223315
+    124:
+        operation: search
+    125:
+        ids_end: 6264887
+        ids_start: 6218348
+        operation: replace
+        tags_end: 9555320
+        tags_start: 9508781
+    126:
+        operation: search
+    127:
+        ids_end: 7256463
+        ids_start: 7234176
+        operation: replace
+        tags_end: 9745034
+        tags_start: 9722747
+    128:
+        operation: search


### PR DESCRIPTION
This PR adds support for 'Replace' operations with BigANN Streaming notebooks.
Details on streaming runbook are [here](https://github.com/harsha-simhadri/big-ann-benchmarks/blob/main/neurips23/streaming/README.md).

PR Pending testing, sending out as draft. 