### PR TITLE
Fix Distance Function for Wiki Cohere

### DIFF
--- a/WikiCohereEnglishEmbeddingBase.cs
+++ b/WikiCohereEnglishEmbeddingBase.cs
@@ -12,7 +12,7 @@ namespace VectorIndexScenarioSuite
         protected override string EmbeddingColumn => "embedding";
         protected override string EmbeddingPath => $"/{EmbeddingColumn}";
         protected override VectorDataType EmbeddingDataType => VectorDataType.Float32;
-        protected override DistanceFunction EmbeddingDistanceFunction => DistanceFunction.Cosine;
+        protected override DistanceFunction EmbeddingDistanceFunction => DistanceFunction.DotProduct;
         protected override ulong EmbeddingDimensions => 768;
         protected override int MaxPhysicalPartitionCount => 56;
  

--- a/WikiCohereEnglishEmbeddingOnlyScenario.cs
+++ b/WikiCohereEnglishEmbeddingOnlyScenario.cs
@@ -18,8 +18,6 @@ namespace VectorIndexScenarioSuite
 
         private static (int, int) DefaultInitialAndFinalThroughput(IConfiguration configurations)
         {
-
-
             // For wiki-cohere scenario, we are starting with :
             // 1) For upto 1M embedding, Collection Create throughput of 400 RU, bumped to 10,000 RU.
             // 2) For 35M embedding, Collection Create throughput of 40,000 RU, bumped to 70,000 RU.


### PR DESCRIPTION
Wiki Cohere uses Inner Product as Distance Function (and not Cosine).