### PR TITLE
 bump the sdk & correct the server latency for muti partition index 

### DIFF
--- a/BigANNBinaryEmbeddingOnlyScearioBase.cs
+++ b/BigANNBinaryEmbeddingOnlyScearioBase.cs
@@ -267,8 +267,15 @@ namespace VectorIndexScenarioSuite
                                 // Similarly, QueryMetrics is null for second and subsequent pages of query results.
                                 if (queryResponse.Diagnostics.GetQueryMetrics() != null)
                                 {
-                                    this.queryMetrics[KVal].AddServerLatencyMeasurement(
-                                        queryResponse.Diagnostics.GetQueryMetrics().CumulativeMetrics.TotalTime.TotalMilliseconds);
+                                    // add per partition server latency
+                                    foreach (var serverMetrics in queryResponse.Diagnostics.GetQueryMetrics().PartitionedMetrics)
+                                    {
+                                        this.queryMetrics[KVal].AddServerLatencyMeasurement(serverMetrics.ServerSideMetrics.TotalTime.TotalMilliseconds);
+                                    }
+
+                                    // this is total server latency
+                                    //this.queryMetrics[KVal].AddServerLatencyMeasurement(
+                                    //    queryResponse.Diagnostics.GetQueryMetrics().CumulativeMetrics.TotalTime.TotalMilliseconds);
                                 }
                             }
                         }
@@ -378,10 +385,8 @@ namespace VectorIndexScenarioSuite
 
                 // only query specific number of point if specific by the config
                 int numQueries = Convert.ToInt32(this.Configurations["AppSettings:scenario:numQueries"]);
-                if (numQueries == 0)
-                {
-                    numQueries = totalQueryVectors;
-                }
+                numQueries = numQueries == 0 ? totalQueryVectors : numQueries;
+
                 for (int kI = 0; kI < K_VALS.Length; kI++)
                 {
                     Console.WriteLine($"Performing {numQueries} queries for Recall/RU/Latency stats for K: {K_VALS[kI]}.");

--- a/BigANNBinaryEmbeddingOnlyScearioBase.cs
+++ b/BigANNBinaryEmbeddingOnlyScearioBase.cs
@@ -375,10 +375,17 @@ namespace VectorIndexScenarioSuite
                 }
 
                 int totalQueryVectors = BigANNBinaryFormat.GetBinaryDataHeader(GetQueryDataPath()).Item1;
+
+                // only query specific number of point if specific by the config
+                int numQueries = Convert.ToInt32(this.Configurations["AppSettings:scenario:numQueries"]);
+                if (numQueries == 0)
+                {
+                    numQueries = totalQueryVectors;
+                }
                 for (int kI = 0; kI < K_VALS.Length; kI++)
                 {
-                    Console.WriteLine($"Performing {totalQueryVectors} queries for Recall/RU/Latency stats for K: {K_VALS[kI]}.");
-                    await PerformQuery(false /* isWarmup */, totalQueryVectors, K_VALS[kI] /*KVal*/, GetQueryDataPath());
+                    Console.WriteLine($"Performing {numQueries} queries for Recall/RU/Latency stats for K: {K_VALS[kI]}.");
+                    await PerformQuery(false /* isWarmup */, numQueries, K_VALS[kI] /*KVal*/, GetQueryDataPath());
                 }
             }
         }

--- a/BigANNBinaryEmbeddingOnlyScearioBase.cs
+++ b/BigANNBinaryEmbeddingOnlyScearioBase.cs
@@ -86,7 +86,7 @@ namespace VectorIndexScenarioSuite
                         Path = this.EmbeddingPath,
                         DataType = this.EmbeddingDataType,
                         DistanceFunction = this.EmbeddingDistanceFunction,
-                        Dimensions = this.EmbeddingDimensions,
+                        Dimensions = (int) this.EmbeddingDimensions,
                     }
                 })),
                 IndexingPolicy = new IndexingPolicy()

--- a/Program.cs
+++ b/Program.cs
@@ -16,7 +16,7 @@ namespace VectorIndexScenarioSuite
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
-                .AddJsonFile(appsettings, optional: true, reloadOnChange: false)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
                 .AddCommandLine(args);
         
             var configurations = builder.Build();

--- a/Program.cs
+++ b/Program.cs
@@ -9,9 +9,14 @@ namespace VectorIndexScenarioSuite
         static async Task Main(string[] args)
         {
             // Setup configuration builder
+            string appsettings = "appsettings.json";
+            if (args.Length > 0) { 
+                appsettings = args[0];
+            }
+
             var builder = new ConfigurationBuilder()
                 .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)
+                .AddJsonFile(appsettings, optional: true, reloadOnChange: false)
                 .AddCommandLine(args);
         
             var configurations = builder.Build();

--- a/Program.cs
+++ b/Program.cs
@@ -9,11 +9,6 @@ namespace VectorIndexScenarioSuite
         static async Task Main(string[] args)
         {
             // Setup configuration builder
-            string appsettings = "appsettings.json";
-            if (args.Length > 0) { 
-                appsettings = args[0];
-            }
-
             var builder = new ConfigurationBuilder()
                 .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: false)

--- a/VectorIndexScenarioSuite.csproj
+++ b/VectorIndexScenarioSuite.csproj
@@ -11,10 +11,11 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.42.0-preview.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="YamlDotNet" Version="16.1.0" />
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/appSettings.json
+++ b/appSettings.json
@@ -15,6 +15,7 @@
       "sliceCount": "100000",
       "runIngestion": true,
       "runQuery": false,
+      "numQueries": 0,// specific num of queries, default 0 will run against entire query file
       /* Number of parallel batches reading dataset file and queing for ingestion */
       "numBulkIngestionBatchCount": 100,
       "warmup": {


### PR DESCRIPTION
1. correct the server latency to per partition server latency, before it's an aggregate latency for muti partition index
2. fix the sdk version, previous version has bug with the muti partition index 
3. specify the number of queries to run in the scenario, default to all queries if not specified in the config file

