### PR TITLE
Introduce Test Coverage in Repo

### DIFF
--- a/VectorIndexScenarioSuite.csproj
+++ b/VectorIndexScenarioSuite.csproj
@@ -2,9 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 	  <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <SatelliteResourceLanguages>en</SatelliteResourceLanguages>  
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup>

--- a/VectorIndexScenarioSuite.csproj
+++ b/VectorIndexScenarioSuite.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-	<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+	  <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
@@ -21,7 +21,7 @@
     <PackageReference Include="YamlDotNet" Version="16.1.0" />
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None> 
+    </None>
     <None Update="runbooks/wikipedia-1M_expirationtime_runbook.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -39,7 +39,10 @@
     </None>
     <None Update="runbooks/wikipedia-35M_expirationtime_replace_delete_runbook.yaml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>         
+    </None> 
+    <None Update="bootemulator.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>        
   </ItemGroup>
   <ItemGroup>
     <Compile Include="src\BigANNBinaryEmbeddingScenarioBase.cs" />
@@ -64,5 +67,14 @@
     <Compile Include="src\WikiCohereEnglishEmbeddingOnlyScenario.cs" />
     <Compile Include="src\filtersearch\AutomotiveEcommerceDocument.cs" />
     <Compile Include="src\filtersearch\AutomotiveEcommerceScenario.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />    
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="test\WikiCohereTest.cs" />
+    <Compile Include="test\VectorTestBase.cs" />
   </ItemGroup>
 </Project>

--- a/appSettings.json
+++ b/appSettings.json
@@ -15,7 +15,7 @@
     "cosmosContainerRUFinal": "0", // Final RU for the container update to leverage the full RU
     "dataFilesBasePath": "C:\\Users\\your-username\\Downloads\\vector-benchmarking\\data",
     "errorLogBasePath": "C:\\Users\\your-username\\Downloads\\vector-benchmarking\\data\\runLog",
-    "deleteContainerOnStart": false,
+    "deleteContainerOnStart": false, // CAUTION: Setting to 'true' will delete the container and all data in it!!!
     "scenario": {
       "name": "wiki-cohere-english-embedding-only-1m-replace-streaming",
       /* Not applicable to streaming scenario but single shot ingestion */

--- a/appSettings.json
+++ b/appSettings.json
@@ -1,5 +1,11 @@
 {
   "AppSettings": {
+    "useEmulator": false,
+    "emulatorSettings": {
+      "emulatorEndPoint": "https://localhost:8081",
+      // Emulator auth key is publicly available and okay to be hardcoded.
+      "emulatorKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+    },
     "accountEndpoint": "https://your-account-endpoint.documents.azure.com:443/",
     "useAADAuth": false,
     "authKey": "your-auth-key",
@@ -9,6 +15,7 @@
     "cosmosContainerRUFinal": "0", // Final RU for the container update to leverage the full RU
     "dataFilesBasePath": "C:\\Users\\your-username\\Downloads\\vector-benchmarking\\data",
     "errorLogBasePath": "C:\\Users\\your-username\\Downloads\\vector-benchmarking\\data\\runLog",
+    "deleteContainerOnStart": false,
     "scenario": {
       "name": "wiki-cohere-english-embedding-only-1m-replace-streaming",
       /* Not applicable to streaming scenario but single shot ingestion */

--- a/bootemulator.ps1
+++ b/bootemulator.ps1
@@ -1,0 +1,65 @@
+# Define the URL for the CosmosDB Emulator MSI
+$cosmosDbEmulatorUrl = "https://aka.ms/cosmosdb-emulator"
+
+# Define the path where the MSI will be downloaded
+$downloadPath = "$env:TEMP\CosmosDBEmulator.msi"
+
+# Check if CosmosDB Emulator is installed
+$emulatorPath = "C:\Program Files\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe"
+if (-Not (Test-Path $emulatorPath)) {
+    Write-Output "CosmosDB Emulator not found. Downloading and installing..."
+
+    if (-Not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
+    {
+        Write-Output "This script requires administrative privileges. Please run bootemulator.ps1 as admin."
+        exit
+    }
+
+    # Download the MSI
+    Invoke-WebRequest -Uri $cosmosDbEmulatorUrl -OutFile $downloadPath
+    
+    # Install the CosmosDB Emulator MSI and emit and errors and warnings to a log file.
+    $logFile = "$env:TEMP\CosmosDBEmulatorInstall.log"
+    Start-Process msiexec.exe -ArgumentList "/i $downloadPath /quiet /norestart /lew $logFile" -Wait
+
+    Get-Content -Path $logFile
+} else {
+    Write-Output "CosmosDB Emulator is already installed."
+}
+
+# Check if the CosmosDB Emulator is already running
+$emulatorProcess = Get-Process -Name "CosmosDB.Emulator" -ErrorAction SilentlyContinue
+if ($null -ne $emulatorProcess) {
+    Write-Output "CosmosDB Emulator is already running."
+} else {
+    # Start the CosmosDB Emulator
+    Write-Output "Starting CosmosDB Emulator..."
+    Start-Process $emulatorPath -ArgumentList "/NoFirewall /Port=8081 
+        /overrides=""enableVectorEmbedding:true;enableVectorIndexQuantizedIndexType:true;enableVectorIndexDiskANNIndexType:true;enableBinaryEncodingOfContent:true;maxResourceSize:2097152"""
+
+    # Wait for the emulator to start
+    $emulatorUri = "https://localhost:8081/_explorer/index.html"
+    $timeoutInSeconds = 60
+    $startTime = Get-Date
+    $isRunning = $false
+
+    Write-Output "Waiting for CosmosDB Emulator to start..."
+    while (-not $isRunning) {
+        try {
+            # Send a request to check if the emulator is running
+            Invoke-WebRequest -Uri $emulatorUri -UseBasicParsing -ErrorAction Stop | Out-Null
+            $isRunning = $true
+            Write-Output "CosmosDB Emulator has started successfully."
+        } catch {
+            # Check if timeout has been reached
+            $elapsedTime = (Get-Date) - $startTime
+            if ($elapsedTime.TotalSeconds -ge $timeoutInSeconds) {
+                Write-Output "Timeout reached. CosmosDB Emulator did not start within $timeoutInSeconds seconds."
+                exit 1
+            }
+
+            # Wait for a short interval before retrying
+            Start-Sleep -Seconds 2
+        }
+    }    
+}

--- a/dataset/wiki_cohere_download.ps1
+++ b/dataset/wiki_cohere_download.ps1
@@ -62,6 +62,11 @@ function CreateSlice {
     $writer.Close()
 }
 
+# Generate 10K Slice
+$basePath = Resolve-Path -Path $destinationFolder\wikipedia_base_35000000.fbin
+$new10KSlicePath = Join-Path $destinationFolder "wikipedia_base_10000.fbin"
+CreateSlice -basePath $basePath -newSliceBasePath $new10KSlicePath -numVectors 10000
+
 # Generate 100K Slice
 $basePath = Resolve-Path -Path $destinationFolder\wikipedia_base_35000000.fbin
 $new100KSlicePath = Join-Path $destinationFolder "wikipedia_base_100000.fbin"

--- a/dataset/wiki_cohere_download.ps1
+++ b/dataset/wiki_cohere_download.ps1
@@ -62,7 +62,7 @@ function CreateSlice {
     $writer.Close()
 }
 
-# Generate 10K Slice
+# Generate 10K Slice (no ground truth, just the vectors)
 $basePath = Resolve-Path -Path $destinationFolder\wikipedia_base_35000000.fbin
 $new10KSlicePath = Join-Path $destinationFolder "wikipedia_base_10000.fbin"
 CreateSlice -basePath $basePath -newSliceBasePath $new10KSlicePath -numVectors 10000

--- a/src/BigANNBinaryEmbeddingScenarioBase.cs
+++ b/src/BigANNBinaryEmbeddingScenarioBase.cs
@@ -102,6 +102,8 @@ namespace VectorIndexScenarioSuite
         protected async Task PerformIngestion(IngestionOperationType ingestionOperationType, int? startTagId, int startVectorId, int totalVectors)
         {
             int numIngestionBatchCount = Convert.ToInt32(this.Configurations["AppSettings:scenario:numIngestionBatchCount"]);
+            numIngestionBatchCount = (numIngestionBatchCount == 0) ? 1 : numIngestionBatchCount;
+
             if (totalVectors % numIngestionBatchCount != 0)
             {
                 throw new ArgumentException("Total vectors should be evenly divisible by numIngestionBatchCount");
@@ -300,7 +302,6 @@ JsonDocumentFactory.GetQueryAsync(dataPath, BinaryDataType.Float32, 0 /* startVe
             string directory = this.Configurations["AppSettings:dataFilesBasePath"] ?? 
                 throw new ArgumentNullException("AppSettings:dataFilesBasePath");
 
-            
             string fileName = $"{this.BaseDataFile}_{this.SliceCount}.{this.BinaryFileExt}";
             return Path.Combine(directory, fileName);
         }

--- a/src/BigANNBinaryFormat.cs
+++ b/src/BigANNBinaryFormat.cs
@@ -179,7 +179,7 @@ namespace VectorIndexScenarioSuite
                         await fileStream.ReadAsync(buffer, 0, sizeof(float));
                         vector[d] = BitConverter.ToSingle(buffer, 0);
                     }
-                    var line = await labelreader.ReadLineAsync();
+                    var line = await labelreader.ReadLineAsync() ?? string.Empty;
 
                     yield return (currentId, vector, line);
                 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -49,7 +49,7 @@ namespace VectorIndexScenarioSuite
             }
         }
 
-        static void TraceConfigKeyValues(IConfiguration configurations)
+        public static void TraceConfigKeyValues(IConfiguration configurations)
         {
             Console.WriteLine("Executing VectorIndexScenarioSuite.");
             foreach (var configuration in configurations.AsEnumerable())
@@ -58,7 +58,7 @@ namespace VectorIndexScenarioSuite
             }
         }
 
-        static Scenario CreateScenario(IConfiguration configurations)
+        public static Scenario CreateScenario(IConfiguration configurations)
         {
             string scenarioName = configurations["AppSettings:scenario:name"] ?? throw new ArgumentNullException("AppSettings:scenario:name");
             Scenarios scenarios = ScenarioParser.Parse(scenarioName);

--- a/src/WikiCohereEnglishEmbeddingOnlyScenario.cs
+++ b/src/WikiCohereEnglishEmbeddingOnlyScenario.cs
@@ -31,6 +31,7 @@ namespace VectorIndexScenarioSuite
             int sliceCount = Convert.ToInt32(configurations["AppSettings:scenario:sliceCount"]);
             switch (sliceCount)
             {
+                case TEN_THOUSAND:
                 case HUNDRED_THOUSAND:
                 case ONE_MILLION:
                     return (400, 10000);

--- a/test/VectorTestBase.cs
+++ b/test/VectorTestBase.cs
@@ -1,0 +1,89 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+
+namespace VectorIndexScenarioSuite.Tests
+{
+    public class VectorTestBase
+    {
+        private const string EmulatorBootScriptPath = "bootemulator.ps1";
+
+        protected static string BaseTestParams = @"
+        {
+            ""AppSettings"": {
+                ""deleteContainerOnStart"": true,
+                ""emulatorSettings"": {
+                  ""emulatorEndPoint"": ""https://localhost:8081"",
+                  // Emulator auth key is publicly available and okay to be hardcoded.
+                  ""emulatorKey"": 
+                        ""C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="",
+                },
+            }
+        }";
+
+        public void SetupCommon(IConfiguration configuration)
+        {
+            bool useEmulator = Convert.ToBoolean(configuration["AppSettings:useEmulator"]);
+            if (useEmulator)
+            {
+                StartEmulator();
+            }
+        }
+
+        public static string UnionJson(string json1, string json2)
+        {
+            if (string.IsNullOrEmpty(json1) || string.IsNullOrEmpty(json2))
+            {
+                throw new ArgumentException("Both JSON strings must be non-empty.");
+            }
+
+            var obj1 = JsonConvert.DeserializeObject<JObject>(json1);
+            var obj2 = JsonConvert.DeserializeObject<JObject>(json2);
+
+            if (obj1 == null || obj2 == null)
+            {
+                throw new InvalidOperationException("Failed to deserialize one or both JSON strings into JObject.");
+            }
+
+            obj1.Merge(obj2, new JsonMergeSettings
+            {
+                MergeArrayHandling = MergeArrayHandling.Union,
+                MergeNullValueHandling = MergeNullValueHandling.Merge
+            });
+
+            return JsonConvert.SerializeObject(obj1, Formatting.Indented);
+        }
+
+        private void StartEmulator()
+        {
+            var processInfo = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                Arguments = $"-ExecutionPolicy Bypass -File \"{EmulatorBootScriptPath}\"",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using (var process = System.Diagnostics.Process.Start(processInfo))
+            {
+                if (process == null)
+                {
+                    throw new System.Exception("Failed to start the emulator process.");
+                }
+
+                process.WaitForExit();
+                var output = process.StandardOutput.ReadToEnd();
+                var error = process.StandardError.ReadToEnd();
+
+                System.Console.WriteLine(output);
+                if (process.ExitCode != 0)
+                {
+                    throw new System.Exception($"Script execution failed: {error}");
+                }
+            }
+        }
+    }
+}

--- a/test/WikiCohereTest.cs
+++ b/test/WikiCohereTest.cs
@@ -13,8 +13,8 @@ namespace VectorIndexScenarioSuite.Tests
                 ""cosmosDatabaseId"": ""wiki-cohere-test-db"",
                 ""cosmosContainerId"": ""wiki-cohere-test-container"",
                 ""name"": ""wiki-cohere-english-embedding-only"",
-                ""dataFilesBasePath"": ""Q:\\dataset\\wiki10m"",
-                ""errorLogBasePath"" : ""Q:\\dataset\\wiki10m"",
+                ""dataFilesBasePath"": ""."",
+                ""errorLogBasePath"" : ""."",
                 ""runIngestion"": true,
                 ""searchListSizeMultiplier"": 10,
                 ""numIngestionBatchCount"": 1,
@@ -37,11 +37,11 @@ namespace VectorIndexScenarioSuite.Tests
             string testSpecificParams = @"
             {
                 ""AppSettings"": {
+                    ""accountEndpoint"": ""https://your-account-endpoint.documents.azure.com:443/"",
+                    ""useAADAuth"": true,
+                    ""authKey"": ""your-auth-key"",
                     ""scenario"": {
                         ""useEmulator"": false,
-                        ""accountEndpoint"": ""https://your-account-endpoint.documents.azure.com:443/"",
-                        ""useAADAuth"": true,
-                        ""authKey"": ""your-auth-key"",
                         ""name"": ""wiki-cohere-english-embedding-only"",  
                         ""sliceCount"": ""10000"",
                         ""runIngestion"": true,
@@ -66,8 +66,8 @@ namespace VectorIndexScenarioSuite.Tests
             string testSpecificParams = @"
             {
                 ""AppSettings"": {
+                    ""useEmulator"": true,
                     ""scenario"": {
-                        ""useEmulator"": true,
                         ""name"": ""wiki-cohere-english-embedding-only"",
                         ""sliceCount"": ""10000"",
                         ""runIngestion"": true,

--- a/test/WikiCohereTest.cs
+++ b/test/WikiCohereTest.cs
@@ -1,0 +1,109 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Extensions.Configuration;
+
+namespace VectorIndexScenarioSuite.Tests
+{
+    [TestClass]
+    public class WikiCohere10K : VectorTestBase
+    {
+        // Releveant configurations.
+        private static string WikiTestParams = @"
+        {
+            ""AppSettings"": {
+                ""useEmulator"": true,
+                ""cosmosDatabaseId"": ""wiki-cohere-test-db"",
+                ""cosmosContainerId"": ""wiki-cohere-test-container"",
+                ""name"": ""wiki-cohere-english-embedding-only"",
+                ""dataFilesBasePath"": ""Q:\\dataset\\wiki10m"",
+                ""errorLogBasePath"" : ""Q:\\dataset\\wiki10m"",
+                ""runIngestion"": true,
+                ""searchListSizeMultiplier"": 10,
+                ""numIngestionBatchCount"": 1,
+                ""startVectorId"": 0,
+                /* Will pick defaults based on sliceCount */
+                ""cosmosContainerRUInitial"": ""0"", 
+                ""cosmosContainerRUFinal"": ""0"",
+                ""scenario"": {
+                    ""computeLatencyAndRUStats"": false,
+                    ""kValues"": [ 10 ]
+                }
+            }
+        }";
+
+        private string SetupParams => UnionJson(WikiTestParams, BaseTestParams);
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+                .AddJsonStream(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(WikiTestParams)));
+
+            var configuration = builder.Build();
+            base.SetupCommon(configuration);
+        }
+
+        [TestMethod]
+        public void WikiCohereIngestionOnlyTest()
+        {
+            string testSpecificParams = @"
+            {
+                ""AppSettings"": {
+                    ""scenario"": {
+                        ""name"": ""wiki-cohere-english-embedding-only"",  
+                        ""sliceCount"": ""10000"",
+                        ""runIngestion"": true,
+                        ""runQuery"": false,
+                        ""ingestWithBulkExecution"": false,
+                        ""computeRecall"": false
+                    }
+            }";
+
+            string testParams = UnionJson(SetupParams, testSpecificParams);
+
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+                .AddJsonStream(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(testParams)));
+            var testConfig = builder.Build();
+
+            Program.TraceConfigKeyValues(testConfig);
+        
+            Scenario scenario = Program.CreateScenario(testConfig);
+            scenario.Setup();
+            scenario.Run().Wait();
+            scenario.Stop();
+        }
+
+        [TestMethod]
+        public void WikiCohereBulkIngestionAndQueryTest()
+        {
+            string testSpecificParams = @"
+            {
+                ""AppSettings"": {
+                    ""scenario"": {
+                        ""name"": ""wiki-cohere-english-embedding-only"",
+                        ""sliceCount"": ""10000"",
+                        ""runIngestion"": true,
+                        ""runQuery"": true,
+                        ""numQueries"": 100,
+                        ""ingestWithBulkExecution"": true,
+                        ""computeRecall"": true
+                    }
+            }";
+
+            string testParams = UnionJson(SetupParams, testSpecificParams);
+
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(AppDomain.CurrentDomain.BaseDirectory)
+                .AddJsonStream(new MemoryStream(System.Text.Encoding.UTF8.GetBytes(testParams)));
+            var testConfig = builder.Build();
+
+            Program.TraceConfigKeyValues(testConfig);
+        
+            Scenario scenario = Program.CreateScenario(testConfig);
+            scenario.Setup();
+            scenario.Run().Wait();
+            scenario.Stop();
+        }
+    }
+}

--- a/test/WikiCohereTest.cs
+++ b/test/WikiCohereTest.cs
@@ -40,8 +40,8 @@ namespace VectorIndexScenarioSuite.Tests
                     ""accountEndpoint"": ""https://your-account-endpoint.documents.azure.com:443/"",
                     ""useAADAuth"": true,
                     ""authKey"": ""your-auth-key"",
+                    ""useEmulator"": false,
                     ""scenario"": {
-                        ""useEmulator"": false,
                         ""name"": ""wiki-cohere-english-embedding-only"",  
                         ""sliceCount"": ""10000"",
                         ""runIngestion"": true,


### PR DESCRIPTION
This PR introduces MSTest in repo with emulator and cloud support. Two sample tests are included as a potential template. Once this PR is in we can slowly backfill testing gap.

------------------
Code has been structured in a way so as we can also boot emulator standalone with included PS script and run the program against it without having to use testing framework.
