### PR TITLE
Addition of endVectorId to specify till how many vectors we want to ingest in a large dataset

### DIFF
--- a/appSettings.json
+++ b/appSettings.json
@@ -28,6 +28,7 @@
       "ingestWithBulkExecution": false, // use bulk client for ingestion
       "numIngestionBatchCount": 1, // Number of parallel batches reading dataset file and queing for ingestion
       "startVectorId": 0, // start vector id for ingestion"
+      "endVectorId": 0, // end vector id for ingestion, if not set will use the entire dataset"
       "warmup": {
         "enabled": false,
         "numWarmupQueries": 1000

--- a/src/BigANNBinaryEmbeddingScenarioBase.cs
+++ b/src/BigANNBinaryEmbeddingScenarioBase.cs
@@ -367,8 +367,10 @@ JsonDocumentFactory.GetQueryAsync(dataPath, BinaryDataType.Float32, 0 /* startVe
 
             if(runIngestion) 
             {
-                int totalVectors = Convert.ToInt32(this.Configurations["AppSettings:scenario:sliceCount"]);
+                int sliceCount = Convert.ToInt32(this.Configurations["AppSettings:scenario:sliceCount"]);
                 int startVectorId = Convert.ToInt32(this.Configurations["AppSettings:scenario:startVectorId"]);
+                int endVectorId = (Convert.ToInt32(this.Configurations["AppSettings:scenario:endVectorId"]) == 0) ? sliceCount : Convert.ToInt32(this.Configurations["AppSettings:scenario:endVectorId"]);
+                int totalVectors = endVectorId - startVectorId;
                 await PerformIngestion(IngestionOperationType.Insert, null /* startTagId */, startVectorId /* startVectorId */, totalVectors);
             }
 

--- a/src/BigANNBinaryEmbeddingScenarioBase.cs
+++ b/src/BigANNBinaryEmbeddingScenarioBase.cs
@@ -369,8 +369,8 @@ JsonDocumentFactory.GetQueryAsync(dataPath, BinaryDataType.Float32, 0 /* startVe
             {
                 int sliceCount = Convert.ToInt32(this.Configurations["AppSettings:scenario:sliceCount"]);
                 int startVectorId = Convert.ToInt32(this.Configurations["AppSettings:scenario:startVectorId"]);
-                int endVectorId = (Convert.ToInt32(this.Configurations["AppSettings:scenario:endVectorId"]) == 0) ? sliceCount : Convert.ToInt32(this.Configurations["AppSettings:scenario:endVectorId"]);
-                int totalVectors = endVectorId - startVectorId;
+                int endVectorId = Convert.ToInt32(this.Configurations["AppSettings:scenario:endVectorId"]);
+                int totalVectors = ((endVectorId == 0) ? sliceCount : endVectorId) - startVectorId;
                 await PerformIngestion(IngestionOperationType.Insert, null /* startTagId */, startVectorId /* startVectorId */, totalVectors);
             }
 


### PR DESCRIPTION
Purpose - Addition of 'endVectorId' in settings to specify till how many vectors we want to ingest in a large dataset
Usecase - In a huge dataset (like 1 billion, 100M) sometimes its required to just ingest a part of the dataset for testing purposes, so adding endVectorId will enable us to ingest vectors upto this id, while the dataset provided can be of more vectors.

This way we will also be able to run multiple VectorIndexSuites by running say 1/4th of workload in one VM, while the other 3 in other VM's, by specifying the correct start and end vector id for each instance.