### PR TITLE
use empty default value for quantizationByteSize

### DIFF
--- a/appSettings.json
+++ b/appSettings.json
@@ -34,7 +34,7 @@
       },
       "computeRecall": false,
       "computeLatencyAndRUStats": false,
-      "quantizationByteSize": "", // Will not use quantizationByteSize if empty.
+      "quantizationByteSize": "", // If empty, cosmosdb will decide an appropriate value.
       "kValues": [ 10 ],
       "streaming": {
         "startOperationId": 1,

--- a/appSettings.json
+++ b/appSettings.json
@@ -34,7 +34,7 @@
       },
       "computeRecall": false,
       "computeLatencyAndRUStats": false,
-      "quantizationByteSize": 0, // Will not use quantizationByteSize if 0.
+      "quantizationByteSize": "", // Will not use quantizationByteSize if empty.
       "kValues": [ 10 ],
       "streaming": {
         "startOperationId": 1,


### PR DESCRIPTION
use empty default value for quantizationByteSize so that by default we dont pass any value