### PR TITLE
Add vector quantizer benchmark tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,14 @@ msbuild.log
 msbuild.err
 msbuild.wrn
 
+# Generated benchmark datasets and run artifacts
+data/runLog/
+data/wikipedia_*.fbin
+data/wikipedia_truth_*
+perf/r3/
+perf/r4/
+perf/*.log
+perf/*.out
+
 # Visual Studio 2015
 .vs/

--- a/VectorIndexScenarioSuite.csproj
+++ b/VectorIndexScenarioSuite.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.13.1" />
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.50.0-preview.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.63.0-preview.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />

--- a/appSettings.json
+++ b/appSettings.json
@@ -38,6 +38,7 @@
       "computeRecall": false,
       "computeLatencyAndRUStats": false,
       "quantizationByteSize": "", // If empty, cosmosdb will decide an appropriate value.
+      "quantizerType": "", // spherical | product. Empty = service default.
       "kValues": [ 10 ],
       "streaming": {
         "startOperationId": 1,

--- a/perf/account-config.example.json
+++ b/perf/account-config.example.json
@@ -1,0 +1,12 @@
+{
+  "account1": {
+    "endpoint": "https://your-account.documents.azure.com:443/",
+    "account": "your-account",
+    "resourceGroup": "your-resource-group"
+  },
+  "account2": {
+    "endpoint": "https://your-second-account.documents.azure.com:443/",
+    "account": "your-second-account",
+    "resourceGroup": "your-second-resource-group"
+  }
+}

--- a/perf/fetch_wikicohere.py
+++ b/perf/fetch_wikicohere.py
@@ -1,0 +1,127 @@
+"""
+Fetch a REAL slice of the BigANN Wikipedia-Cohere dataset (35M x 768, inner-product)
+and produce the files the VectorIndexScenarioSuite wiki-cohere scenario reads:
+
+  wikipedia_base_<nbase>.fbin   : first <nbase> real base vectors (header rewritten)
+  wikipedia_query.fbin          : first <nquery> real query vectors
+  wikipedia_truth_<nbase>       : exact top-<gtk> neighbors per query (BigANN GT format),
+                                  computed locally by exact dot product over the crop.
+
+Source (see big-ann-benchmarks datasets.py, class WikipediaDataset):
+  base : https://comp21storage.z5.web.core.windows.net/wiki-cohere-35M/wikipedia_base.bin
+  query: https://comp21storage.z5.web.core.windows.net/wiki-cohere-35M/wikipedia_query.bin
+  distance = inner product (dot product); dtype float32; d = 768.
+
+We use HTTP range GETs so only ~(8 + d*n*4) bytes are downloaded, not the full 107 GB.
+"""
+import argparse
+import os
+import struct
+import urllib.request
+
+import numpy as np
+
+BASE_URL = "https://comp21storage.z5.web.core.windows.net/wiki-cohere-35M/wikipedia_base.bin"
+QUERY_URL = "https://comp21storage.z5.web.core.windows.net/wiki-cohere-35M/wikipedia_query.bin"
+DIM = 768
+DTYPE = np.float32
+ITEMSIZE = 4
+
+
+def range_get(url, nbytes):
+    """Download the first nbytes bytes of url via an HTTP range request."""
+    req = urllib.request.Request(url, headers={"Range": f"bytes=0-{nbytes - 1}"})
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        data = resp.read()
+    if len(data) != nbytes:
+        raise RuntimeError(f"expected {nbytes} bytes, got {len(data)} from {url}")
+    return data
+
+
+def read_fbin_bytes(raw, expected_count, expected_dim):
+    count = struct.unpack_from("<i", raw, 0)[0]
+    dim = struct.unpack_from("<i", raw, 4)[0]
+    if dim != expected_dim:
+        raise RuntimeError(f"dim mismatch: header dim={dim}, expected {expected_dim}")
+    if count < expected_count:
+        raise RuntimeError(f"source only has {count} vectors, need {expected_count}")
+    arr = np.frombuffer(raw, dtype=DTYPE, count=expected_count * dim, offset=8)
+    return arr.reshape(expected_count, dim).copy()
+
+
+def write_fbin(path, arr):
+    n, d = arr.shape
+    with open(path, "wb") as f:
+        f.write(struct.pack("<i", n))
+        f.write(struct.pack("<i", d))
+        f.write(arr.astype(DTYPE).tobytes())
+
+
+def write_ground_truth(path, ids, scores):
+    nq, k = ids.shape
+    with open(path, "wb") as f:
+        f.write(struct.pack("<i", nq))
+        f.write(struct.pack("<i", k))
+        f.write(ids.astype(np.int32).tobytes())
+        f.write(scores.astype(np.float32).tobytes())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--outdir", required=True)
+    ap.add_argument("--nbase", type=int, default=5000)
+    ap.add_argument("--nquery", type=int, default=50)
+    ap.add_argument("--gtk", type=int, default=100)
+    ap.add_argument("--reuse-base", action="store_true",
+                    help="Reuse an existing wikipedia_base_<nbase>.fbin if present with a matching "
+                         "header, instead of re-downloading (the crop is deterministic).")
+    args = ap.parse_args()
+
+    os.makedirs(args.outdir, exist_ok=True)
+
+    base_bytes = 8 + DIM * args.nbase * ITEMSIZE
+    query_bytes = 8 + DIM * args.nquery * ITEMSIZE
+
+    base_path = os.path.join(args.outdir, f"wikipedia_base_{args.nbase}.fbin")
+    reuse = False
+    if args.reuse_base and os.path.exists(base_path):
+        with open(base_path, "rb") as f:
+            hdr = f.read(8)
+        if len(hdr) == 8 and struct.unpack("<ii", hdr) == (args.nbase, DIM):
+            reuse = True
+    if reuse:
+        print(f"Reusing existing base {base_path} ({args.nbase}x{DIM}) ...")
+        with open(base_path, "rb") as f:
+            base = read_fbin_bytes(f.read(base_bytes), args.nbase, DIM)
+    else:
+        print(f"Downloading {base_bytes/1e6:.1f} MB of real base vectors ...")
+        base = read_fbin_bytes(range_get(BASE_URL, base_bytes), args.nbase, DIM)
+    print(f"Downloading {query_bytes/1e6:.1f} MB of real query vectors ...")
+    query = read_fbin_bytes(range_get(QUERY_URL, query_bytes), args.nquery, DIM)
+
+    # Exact top-gtk by INNER PRODUCT (dataset metric == DotProduct in the scenario).
+    k = min(args.gtk, args.nbase)
+    sims = query @ base.T  # (nquery, nbase)
+    part = np.argpartition(-sims, kth=k - 1, axis=1)[:, :k]
+    part_scores = np.take_along_axis(sims, part, axis=1)
+    order = np.argsort(-part_scores, axis=1)
+    gt_ids = np.take_along_axis(part, order, axis=1)
+    gt_scores = np.take_along_axis(part_scores, order, axis=1)
+
+    query_path = os.path.join(args.outdir, "wikipedia_query.fbin")
+    gt_path = os.path.join(args.outdir, f"wikipedia_truth_{args.nbase}")
+
+    if not reuse:
+        write_fbin(base_path, base)
+    write_fbin(query_path, query)
+    write_ground_truth(gt_path, gt_ids, gt_scores)
+
+    print(f"REAL wiki-cohere: nbase={args.nbase} nquery={args.nquery} dim={DIM} gtk={k} "
+          f"metric=innerproduct")
+    print(f"wrote {base_path}")
+    print(f"wrote {query_path}")
+    print(f"wrote {gt_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/perf/gen_dataset.py
+++ b/perf/gen_dataset.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Generate a synthetic vector dataset (BigANN .fbin format) plus an exact
+ground-truth file for recall evaluation, used by the spherical-vs-product
+quantizer comparison harness.
+
+Outputs (into --outdir):
+  wikipedia_base_<nbase>.fbin   : nbase x dim float32 base vectors
+  wikipedia_query.fbin          : nquery x dim float32 query vectors
+  wikipedia_truth_<nbase>       : exact top-gtK neighbors per query (BigANN GT format)
+
+fbin format:  int32 count, int32 dim, then count*dim float32.
+GT format  :  int32 nquery, int32 gtK,
+              then nquery*gtK int32 neighbor ids,
+              then nquery*gtK float32 similarity scores.
+Ground truth is computed by exact dot-product (DistanceFunction.DotProduct):
+nearest neighbors = highest dot product (descending).
+"""
+import argparse
+import numpy as np
+
+
+def write_fbin(path, arr):
+    arr = np.ascontiguousarray(arr, dtype=np.float32)
+    n, d = arr.shape
+    with open(path, "wb") as f:
+        np.array([n, d], dtype=np.int32).tofile(f)
+        arr.tofile(f)
+
+
+def write_ground_truth(path, ids, scores):
+    nq, k = ids.shape
+    with open(path, "wb") as f:
+        np.array([nq, k], dtype=np.int32).tofile(f)
+        np.ascontiguousarray(ids, dtype=np.int32).tofile(f)
+        np.ascontiguousarray(scores, dtype=np.float32).tofile(f)
+
+
+def gen_vectors(dist, n, dim, rng):
+    if dist == "gaussian":
+        return rng.standard_normal((n, dim)).astype(np.float32)
+    if dist == "clustered":
+        n_clusters = 50
+        centers = rng.standard_normal((n_clusters, dim)).astype(np.float32) * 5.0
+        assign = rng.integers(0, n_clusters, size=n)
+        noise = rng.standard_normal((n, dim)).astype(np.float32) * 0.5
+        return centers[assign] + noise
+    if dist == "uniform":
+        return rng.random((n, dim), dtype=np.float32) * 2.0 - 1.0
+    raise ValueError(f"unknown dist {dist}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--outdir", required=True)
+    ap.add_argument("--dist", default="gaussian", choices=["gaussian", "clustered", "uniform"])
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--nbase", type=int, default=5000)
+    ap.add_argument("--nquery", type=int, default=50)
+    ap.add_argument("--dim", type=int, default=768)
+    ap.add_argument("--gtk", type=int, default=100)
+    args = ap.parse_args()
+
+    rng = np.random.default_rng(args.seed)
+    base = gen_vectors(args.dist, args.nbase, args.dim, rng)
+    query = gen_vectors(args.dist, args.nquery, args.dim, rng)
+
+    # Exact top-gtK by dot product (DotProduct distance function): highest dot product first.
+    # base: (nbase, dim), query: (nquery, dim) -> sims: (nquery, nbase)
+    sims = query @ base.T
+    k = min(args.gtk, args.nbase)
+    # argpartition for top-k, then sort those k descending.
+    part = np.argpartition(-sims, kth=k - 1, axis=1)[:, :k]
+    part_scores = np.take_along_axis(sims, part, axis=1)
+    order = np.argsort(-part_scores, axis=1)
+    gt_ids = np.take_along_axis(part, order, axis=1).astype(np.int32)
+    gt_scores = np.take_along_axis(part_scores, order, axis=1).astype(np.float32)
+
+    base_path = f"{args.outdir}/wikipedia_base_{args.nbase}.fbin"
+    query_path = f"{args.outdir}/wikipedia_query.fbin"
+    gt_path = f"{args.outdir}/wikipedia_truth_{args.nbase}"
+
+    write_fbin(base_path, base)
+    write_fbin(query_path, query)
+    write_ground_truth(gt_path, gt_ids, gt_scores)
+
+    print(f"dist={args.dist} seed={args.seed} nbase={args.nbase} nquery={args.nquery} "
+          f"dim={args.dim} gtK={k}")
+    print(f"wrote {base_path}")
+    print(f"wrote {query_path}")
+    print(f"wrote {gt_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/perf/idxctl/Program.cs
+++ b/perf/idxctl/Program.cs
@@ -1,0 +1,186 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+
+// idxctl: manage vector index policy for the "index-after-ingest" (r4) experiment.
+//
+// Commands:
+//   create-noindex <endpoint> <db> <container> <ru>
+//       Create container WITH the WikiCohere VectorEmbeddingPolicy (immutable, required)
+//       but WITHOUT any VectorIndexes. IncludedPath "/", ExcludedPath "/embedding/*".
+//   add-index    <endpoint> <db> <container> <quantizer> <byteSize>
+//       ReplaceContainer to ADD a DiskANN vector index on /embedding carrying the
+//       given quantizerType (product|spherical; "" = default) and quantizationByteSize
+//       (0/"" = default). Then poll index-transformation-progress.
+//   show-index   <endpoint> <db> <container>
+//       Print current VectorEmbeddingPolicy + IndexingPolicy.VectorIndexes.
+//
+// WikiCohere embedding spec (must match the suite exactly):
+//   PartitionKey /id ; EmbeddingPath /embedding ; Float32 ; DotProduct ; 768 dims.
+class Program
+{
+    const string EmbeddingPath = "/embedding";
+    const string PartitionKeyPath = "/id";
+    const int Dimensions = 768;
+
+    static async Task<int> Main(string[] args)
+    {
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("usage: idxctl <create-noindex|add-index|show-index> ...");
+            return 2;
+        }
+        string cmd = args[0];
+        try
+        {
+            switch (cmd)
+            {
+                case "create-noindex": return await CreateNoIndex(args);
+                case "add-index":      return await AddIndex(args);
+                case "show-index":     return await ShowIndex(args);
+                default:
+                    Console.Error.WriteLine($"unknown command '{cmd}'");
+                    return 2;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"IDXCTL_JSON: {{\"cmd\":\"{cmd}\",\"ok\":false,\"error\":\"{Escape(ex.Message)}\"}}");
+            Console.Error.WriteLine(ex.ToString());
+            return 1;
+        }
+    }
+
+    static CosmosClient MakeClient(string endpoint)
+    {
+        var options = new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, LimitToEndpoint = true };
+        return new CosmosClient(endpoint, new DefaultAzureCredential(), options);
+    }
+
+    static VectorEmbeddingPolicy MakeEmbeddingPolicy()
+    {
+        return new VectorEmbeddingPolicy(new Collection<Embedding>(new List<Embedding>()
+        {
+            new Embedding()
+            {
+                Path = EmbeddingPath,
+                DataType = VectorDataType.Float32,
+                DistanceFunction = DistanceFunction.DotProduct,
+                Dimensions = Dimensions,
+            }
+        }));
+    }
+
+    static VectorIndexPath MakeVectorIndexPath(string quantizer, string byteSize)
+    {
+        var vip = new VectorIndexPath() { Path = EmbeddingPath, Type = VectorIndexType.DiskANN };
+        if (!string.IsNullOrEmpty(quantizer))
+        {
+            if (!Enum.TryParse<QuantizerType>(quantizer, ignoreCase: true, out var qt))
+                throw new ArgumentException($"Invalid quantizerType '{quantizer}'.");
+            vip.QuantizerType = qt;
+        }
+        if (!string.IsNullOrEmpty(byteSize) && byteSize != "0")
+        {
+            int bs = Convert.ToInt32(byteSize);
+            if (bs <= 0) throw new ArgumentException("byteSize must be > 0");
+            vip.QuantizationByteSize = bs;
+        }
+        return vip;
+    }
+
+    static async Task<int> CreateNoIndex(string[] a)
+    {
+        if (a.Length < 5) { Console.Error.WriteLine("usage: idxctl create-noindex <endpoint> <db> <container> <ru>"); return 2; }
+        string endpoint = a[1], db = a[2], coll = a[3]; int ru = Convert.ToInt32(a[4]);
+        using var client = MakeClient(endpoint);
+        Database database = client.GetDatabase(db);
+
+        var props = new ContainerProperties(id: coll, partitionKeyPath: PartitionKeyPath)
+        {
+            VectorEmbeddingPolicy = MakeEmbeddingPolicy(),
+            IndexingPolicy = new IndexingPolicy()  // NOTE: no VectorIndexes
+        };
+        props.IndexingPolicy.IncludedPaths.Add(new IncludedPath { Path = "/" });
+        props.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = EmbeddingPath + "/*" });
+
+        ContainerResponse resp = await database.CreateContainerIfNotExistsAsync(props, throughput: ru);
+        int viCount = resp.Resource?.IndexingPolicy?.VectorIndexes?.Count ?? 0;
+        bool hasEmbed = (resp.Resource?.VectorEmbeddingPolicy != null);
+        Console.WriteLine($"IDXCTL_JSON: {{\"cmd\":\"create-noindex\",\"ok\":true,\"container\":\"{coll}\",\"status\":\"{(int)resp.StatusCode}\",\"vectorIndexes\":{viCount},\"hasEmbeddingPolicy\":{hasEmbed.ToString().ToLower()},\"ru\":{ru}}}");
+        return 0;
+    }
+
+    static async Task<int> AddIndex(string[] a)
+    {
+        if (a.Length < 4) { Console.Error.WriteLine("usage: idxctl add-index <endpoint> <db> <container> [quantizer] [byteSize]"); return 2; }
+        string endpoint = a[1], db = a[2], coll = a[3];
+        string quantizer = a.Length > 4 ? a[4] : "";
+        string byteSize  = a.Length > 5 ? a[5] : "";
+        using var client = MakeClient(endpoint);
+        Container container = client.GetContainer(db, coll);
+
+        ContainerResponse cur = await container.ReadContainerAsync();
+        ContainerProperties props = cur.Resource;
+        int before = props.IndexingPolicy?.VectorIndexes?.Count ?? 0;
+
+        // Ensure excluded path present, then add the vector index.
+        bool hasExcluded = props.IndexingPolicy.ExcludedPaths.Any(p => p.Path == EmbeddingPath + "/*");
+        if (!hasExcluded) props.IndexingPolicy.ExcludedPaths.Add(new ExcludedPath { Path = EmbeddingPath + "/*" });
+        if (props.IndexingPolicy.VectorIndexes == null) props.IndexingPolicy.VectorIndexes = new Collection<VectorIndexPath>();
+        props.IndexingPolicy.VectorIndexes.Clear();
+        props.IndexingPolicy.VectorIndexes.Add(MakeVectorIndexPath(quantizer, byteSize));
+
+        DateTime t0 = DateTime.UtcNow;
+        ContainerResponse repl = await container.ReplaceContainerAsync(props);
+        int after = repl.Resource?.IndexingPolicy?.VectorIndexes?.Count ?? 0;
+        string effQuant = (after > 0) ? repl.Resource.IndexingPolicy.VectorIndexes[0].QuantizerType.ToString() : "";
+        var effBs = (after > 0) ? repl.Resource.IndexingPolicy.VectorIndexes[0].QuantizationByteSize : (int?)null;
+        Console.WriteLine($"IDXCTL_JSON: {{\"cmd\":\"add-index\",\"ok\":true,\"container\":\"{coll}\",\"replaceStatus\":\"{(int)repl.StatusCode}\",\"vectorIndexesBefore\":{before},\"vectorIndexesAfter\":{after},\"effectiveQuantizer\":\"{effQuant}\",\"effectiveByteSize\":{(effBs.HasValue ? effBs.Value.ToString() : "null")}}}");
+
+        // Poll scalar index-transformation-progress (DiskANN graph builds async in the backend).
+        for (int i = 0; i < 20; i++)
+        {
+            await Task.Delay(3000);
+            ContainerResponse r = await container.ReadContainerAsync();
+            string prog = r.Headers?["x-ms-documentdb-collection-index-transformation-progress"];
+            double secs = (DateTime.UtcNow - t0).TotalSeconds;
+            Console.WriteLine($"IDXCTL_PROGRESS: {{\"container\":\"{coll}\",\"tSec\":{secs:F0},\"indexTransformationProgress\":\"{prog}\"}}");
+            if (prog == "100" || prog == "-1" || string.IsNullOrEmpty(prog)) break;
+        }
+        return 0;
+    }
+
+    static async Task<int> ShowIndex(string[] a)
+    {
+        if (a.Length < 4) { Console.Error.WriteLine("usage: idxctl show-index <endpoint> <db> <container>"); return 2; }
+        string endpoint = a[1], db = a[2], coll = a[3];
+        using var client = MakeClient(endpoint);
+        Container container = client.GetContainer(db, coll);
+        ContainerResponse cur = await container.ReadContainerAsync();
+        using ResponseMessage raw = await container.ReadContainerStreamAsync();
+        raw.EnsureSuccessStatusCode();
+        using var reader = new StreamReader(raw.Content);
+        string resourceId = JObject.Parse(await reader.ReadToEndAsync())["_rid"]?.ToString() ?? "";
+        var vis = cur.Resource?.IndexingPolicy?.VectorIndexes;
+        int viCount = vis?.Count ?? 0;
+        string details = "";
+        if (viCount > 0)
+        {
+            var parts = vis.Select(v => $"{{\\\"path\\\":\\\"{v.Path}\\\",\\\"type\\\":\\\"{v.Type}\\\",\\\"quantizer\\\":\\\"{v.QuantizerType}\\\",\\\"byteSize\\\":{v.QuantizationByteSize}}}");
+            details = string.Join(",", parts);
+        }
+        bool hasEmbed = (cur.Resource?.VectorEmbeddingPolicy != null);
+        Console.WriteLine($"IDXCTL_JSON: {{\"cmd\":\"show-index\",\"ok\":true,\"container\":\"{coll}\",\"resourceId\":\"{Escape(resourceId)}\",\"hasEmbeddingPolicy\":{hasEmbed.ToString().ToLower()},\"vectorIndexes\":{viCount},\"details\":[{details}]}}");
+        return 0;
+    }
+
+    static string Escape(string s) => (s ?? "").Replace("\\", "\\\\").Replace("\"", "\\\"").Replace("\r", " ").Replace("\n", " ");
+}

--- a/perf/idxctl/idxctl.csproj
+++ b/perf/idxctl/idxctl.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>idxctl</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.63.0-preview.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+  </ItemGroup>
+</Project>

--- a/perf/pcheck/Program.cs
+++ b/perf/pcheck/Program.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using Azure.Identity;
+using Microsoft.Azure.Cosmos;
+
+// pcheck: authoritative physical-partition count + throughput for a container.
+// Usage: pcheck <endpoint> <database> <container>
+// Prints one line: PCHECK_JSON: {"container":...,"feedRanges":N,"docCount":D}
+class Program
+{
+    static async Task<int> Main(string[] args)
+    {
+        if (args.Length < 3)
+        {
+            Console.Error.WriteLine("usage: pcheck <endpoint> <database> <container>");
+            return 2;
+        }
+        string endpoint = args[0], db = args[1], coll = args[2];
+        var options = new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway, LimitToEndpoint = true };
+        using var client = new CosmosClient(endpoint, new DefaultAzureCredential(), options);
+        Container container = client.GetContainer(db, coll);
+
+        // One FeedRange per physical partition = authoritative partition count.
+        IReadOnlyList<FeedRange> ranges = await container.GetFeedRangesAsync();
+        int feedRanges = ranges.Count;
+
+        long docCount = -1;
+        try
+        {
+            using var it = container.GetItemQueryIterator<long>("SELECT VALUE COUNT(1) FROM c");
+            if (it.HasMoreResults)
+            {
+                var resp = await it.ReadNextAsync();
+                docCount = resp.FirstOrDefault();
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"docCount query failed: {ex.Message}");
+        }
+
+        Console.WriteLine($"PCHECK_JSON: {{\"container\":\"{coll}\",\"feedRanges\":{feedRanges},\"docCount\":{docCount}}}");
+        return 0;
+    }
+}

--- a/perf/pcheck/pcheck.csproj
+++ b/perf/pcheck/pcheck.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>pcheck</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.63.0-preview.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Azure.Identity" Version="1.13.1" />
+  </ItemGroup>
+</Project>

--- a/perf/run_comparison.ps1
+++ b/perf/run_comparison.ps1
@@ -1,0 +1,140 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+  Spherical vs Product quantizer comparison harness for VectorIndexScenarioSuite.
+
+  Uses the REAL BigANN Wikipedia-Cohere dataset (35M x 768, inner-product). For each
+  requested base slice size and each quantizer type (product = default, spherical), this:
+    1. Downloads a real cropped wiki-cohere slice + real queries and computes exact
+       ground truth locally via fetch_wikicohere.py (HTTP range GET; ~15 MB per slice).
+    2. Runs the suite against a SEPARATE collection (<label>-<quantizer>), creating it
+       fresh via the Cosmos SQL SDK with the chosen quantizerType.
+    3. Captures the RESULT_JSON summary line (insert time, lazy catch-up time, query time,
+       recall, and DiskANN-usage validation).
+  Finally it prints a comparison table and writes results.csv / results.json.
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [int]$NQuery = 50,
+    [int]$RUInitial = 8000,
+    [int]$RUFinal = 10000,
+    [int]$CatchupTimeoutMin = 30,
+    [string[]]$Quantizers = @("product", "spherical"),
+    # Real wiki-cohere base-slice sizes to sweep. Each size is one "dataset".
+    [int[]]$BaseSizes = @(5000),
+    # Optional container-name label override (default "wikicohere<NBase>"). Lets runs at
+    # different RU/accounts use distinct collections instead of clobbering each other.
+    [string]$Label = "",
+    # Optional Cosmos account endpoint override (AAD). Empty = use appSettings.json.
+    [string]$AccountEndpoint = "",
+    # Reuse already-downloaded base file (deterministic crop) instead of re-fetching.
+    [switch]$ReuseBase,
+    # Skip fetching entirely (data files already present). Needed when running multiple
+    # instances concurrently so they don't race writing the same data files.
+    [switch]$SkipFetch
+)
+
+$ErrorActionPreference = "Stop"
+$exe = Join-Path $RepoRoot "bin\Release\net8.0\win-x64\VectorIndexScenarioSuite.exe"
+$dataDir = Join-Path $RepoRoot "data"
+$fetch = Join-Path $RepoRoot "perf\fetch_wikicohere.py"
+$outDir = Join-Path $RepoRoot "perf\out"
+New-Item -ItemType Directory -Force -Path $dataDir, $outDir | Out-Null
+
+if (-not (Test-Path $exe)) { throw "Executable not found: $exe (build first)" }
+
+$results = New-Object System.Collections.Generic.List[object]
+
+foreach ($NBase in $BaseSizes) {
+    $label = if ($Label) { $Label } else { "wikicohere$NBase" }
+
+    Write-Host "`n=== Fetching REAL wiki-cohere slice '$label' (nbase=$NBase) ===" -ForegroundColor Cyan
+    if ($SkipFetch) {
+        Write-Host "  -SkipFetch set; using existing data files on disk." -ForegroundColor DarkYellow
+    }
+    else {
+        $fetchArgs = @("--outdir", $dataDir, "--nbase", $NBase, "--nquery", $NQuery, "--gtk", "100")
+        if ($ReuseBase) { $fetchArgs += "--reuse-base" }
+        python $fetch @fetchArgs
+        if ($LASTEXITCODE -ne 0) { throw "real wiki-cohere fetch failed for $label" }
+    }
+
+    foreach ($q in $Quantizers) {
+        $container = "$label-$q"
+        Write-Host "`n--- Run: dataset=$label quantizer=$q container=$container ---" -ForegroundColor Yellow
+
+        $args = @(
+            "--AppSettings:scenario:name=wiki-cohere-english-embedding-only",
+            "--AppSettings:cosmosContainerId=$container",
+            "--AppSettings:scenario:quantizerType=$q",
+            "--AppSettings:scenario:datasetLabel=$label",
+            "--AppSettings:scenario:sliceCount=$NBase",
+            "--AppSettings:scenario:startVectorId=0",
+            "--AppSettings:scenario:endVectorId=$NBase",
+            "--AppSettings:scenario:numQueries=$NQuery",
+            "--AppSettings:scenario:runIngestion=true",
+            "--AppSettings:scenario:runQuery=true",
+            "--AppSettings:scenario:computeRecall=true",
+            "--AppSettings:scenario:computeLatencyAndRUStats=true",
+            "--AppSettings:scenario:ingestWithBulkExecution=true",
+            "--AppSettings:cosmosContainerRUInitial=$RUInitial",
+            "--AppSettings:cosmosContainerRUFinal=$RUFinal",
+            "--AppSettings:scenario:catchupTimeoutMinutes=$CatchupTimeoutMin",
+            "--AppSettings:deleteContainerOnStart=true",
+            "--AppSettings:waitForUserInputBeforeExit=false"
+        )
+        if ($AccountEndpoint) {
+            $args += "--AppSettings:accountEndpoint=$AccountEndpoint"
+            $args += "--AppSettings:useAADAuth=true"
+        }
+
+        $logFile = Join-Path $outDir "$container.log"
+        # Pipe a newline for the final Console.ReadLine(); tee full output to a per-run log.
+        "" | & $exe @args 2>&1 | Tee-Object -FilePath $logFile | Out-Null
+
+        $resultLine = Select-String -Path $logFile -Pattern '^RESULT_JSON: ' | Select-Object -Last 1
+        if ($null -eq $resultLine) {
+            Write-Host "  WARNING: no RESULT_JSON produced for $container (see $logFile)" -ForegroundColor Red
+            continue
+        }
+        $json = $resultLine.Line -replace '^RESULT_JSON: ', ''
+        $obj = $json | ConvertFrom-Json
+        $results.Add($obj)
+        Write-Host ("  insert={0:N1}s catchup={1:N1}s query={2:N1}s recall@10={3} diskAnnUsed={4} effQuantizer={5}" -f `
+            ($obj.ingestionDurationMs/1000), ($obj.indexCatchupDurationMs/1000), `
+            ($obj.queryPhaseDurationMs/1000), $obj.recall.'10', $obj.diskAnnUsed, $obj.effectiveQuantizerType) -ForegroundColor Green
+    }
+}
+
+if ($results.Count -eq 0) { throw "No results collected." }
+
+# ---- Report ----
+$rows = $results | ForEach-Object {
+    [pscustomobject]@{
+        Dataset          = $_.datasetLabel
+        Quantizer        = $_.quantizerType
+        EffQuantizer     = $_.effectiveQuantizerType
+        Container        = $_.container
+        Vectors          = $_.ingestedVectors
+        InsertSec        = [math]::Round($_.ingestionDurationMs/1000, 1)
+        CatchupSec       = [math]::Round($_.indexCatchupDurationMs/1000, 1)
+        QuerySec         = [math]::Round($_.queryPhaseDurationMs/1000, 1)
+        QueryLatencyMs   = [math]::Round($_.avgQueryClientLatencyMs, 1)
+        QueryRU          = [math]::Round($_.avgQueryRU, 2)
+        'Recall@10'      = $_.recall.'10'
+        DiskAnnUsed      = $_.diskAnnUsed
+        ApproxDocs       = $_.diskAnnApproxRetrievedDocs
+        ExactDocs        = $_.diskAnnExactRetrievedDocs
+        'Overlap%'       = $_.diskAnnApproxVsExactOverlapPct
+    }
+}
+
+Write-Host "`n================ COMPARISON: Spherical vs Product Quantizer ================" -ForegroundColor Cyan
+$rows | Sort-Object Dataset, Quantizer | Format-Table -AutoSize
+
+$csvPath = Join-Path $outDir ("results{0}.csv" -f ($(if ($Label) { "-$Label" } else { "" })))
+$jsonPath = Join-Path $outDir ("results{0}.json" -f ($(if ($Label) { "-$Label" } else { "" })))
+$rows | Export-Csv -Path $csvPath -NoTypeInformation
+$results | ConvertTo-Json -Depth 6 | Set-Content -Path $jsonPath
+Write-Host "Wrote $csvPath and $jsonPath"

--- a/perf/run_query_only.ps1
+++ b/perf/run_query_only.ps1
@@ -1,0 +1,96 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+  Query-only run against EXISTING wiki-cohere collections (no ingestion, no delete).
+  For each collection it runs warmup + numQueries measured queries and captures RESULT_JSON
+  (query latency/RU, recall, DiskANN-usage validation).
+
+  SAFETY: deleteContainerOnStart=false and runIngestion=false so existing data is untouched.
+#>
+[CmdletBinding()]
+param(
+    [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+    [int]$NBase = 100000,
+    [int]$NQuery = 500,
+    [int]$NWarmup = 500,
+    # Collection;quantizerType pairs to query.
+    [string[]]$Targets = @("wikicohere100000-product;product", "wikicohere100000-spherical;spherical"),
+    # Optional Cosmos account endpoint override (AAD). Empty = use appSettings.json.
+    [string]$AccountEndpoint = ""
+)
+
+$ErrorActionPreference = "Stop"
+$exe = Join-Path $RepoRoot "bin\Release\net8.0\win-x64\VectorIndexScenarioSuite.exe"
+$outDir = Join-Path $RepoRoot "perf\out"
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+if (-not (Test-Path $exe)) { throw "Executable not found: $exe (build first)" }
+
+$results = New-Object System.Collections.Generic.List[object]
+
+foreach ($t in $Targets) {
+    $parts = $t.Split(";")
+    $container = $parts[0]; $q = $parts[1]
+    Write-Host "`n--- Query-only: container=$container quantizer=$q warmup=$NWarmup queries=$NQuery ---" -ForegroundColor Yellow
+
+    $args = @(
+        "--AppSettings:scenario:name=wiki-cohere-english-embedding-only",
+        "--AppSettings:cosmosContainerId=$container",
+        "--AppSettings:scenario:quantizerType=$q",
+        "--AppSettings:scenario:datasetLabel=wikicohere$NBase",
+        "--AppSettings:scenario:sliceCount=$NBase",
+        "--AppSettings:scenario:startVectorId=0",
+        "--AppSettings:scenario:endVectorId=$NBase",
+        "--AppSettings:scenario:numQueries=$NQuery",
+        "--AppSettings:scenario:runIngestion=false",
+        "--AppSettings:scenario:runQuery=true",
+        "--AppSettings:scenario:computeRecall=true",
+        "--AppSettings:scenario:computeLatencyAndRUStats=true",
+        "--AppSettings:scenario:warmup:enabled=true",
+        "--AppSettings:scenario:warmup:numWarmupQueries=$NWarmup",
+        # Do NOT touch throughput or delete data.
+        "--AppSettings:cosmosContainerRUInitial=0",
+        "--AppSettings:cosmosContainerRUFinal=0",
+        "--AppSettings:deleteContainerOnStart=false",
+        "--AppSettings:waitForUserInputBeforeExit=false"
+    )
+    if ($AccountEndpoint) {
+        $args += "--AppSettings:accountEndpoint=$AccountEndpoint"
+        $args += "--AppSettings:useAADAuth=true"
+    }
+
+    $logFile = Join-Path $outDir "queryonly-$container.log"
+    "" | & $exe @args 2>&1 | Tee-Object -FilePath $logFile | Out-Null
+
+    $resultLine = Select-String -Path $logFile -Pattern '^RESULT_JSON: ' | Select-Object -Last 1
+    if ($null -eq $resultLine) {
+        Write-Host "  WARNING: no RESULT_JSON for $container (see $logFile)" -ForegroundColor Red
+        continue
+    }
+    $obj = ($resultLine.Line -replace '^RESULT_JSON: ', '') | ConvertFrom-Json
+    $results.Add($obj)
+    Write-Host ("  queryLatMs={0:N1} queryRU={1:N2} recall@10={2} diskAnnUsed={3} effQuantizer={4}" -f `
+        $obj.avgQueryClientLatencyMs, $obj.avgQueryRU, $obj.recall.'10', $obj.diskAnnUsed, $obj.effectiveQuantizerType) `
+        -ForegroundColor Green
+}
+
+if ($results.Count -eq 0) { throw "No results collected." }
+
+$rows = $results | ForEach-Object {
+    [pscustomobject]@{
+        Container      = $_.container
+        EffQuantizer   = $_.effectiveQuantizerType
+        QueriesRun     = $NQuery
+        QueryLatencyMs = [math]::Round($_.avgQueryClientLatencyMs, 2)
+        QueryRU        = [math]::Round($_.avgQueryRU, 2)
+        'Recall@10'    = $_.recall.'10'
+        DiskAnnUsed    = $_.diskAnnUsed
+        ApproxDocs     = $_.diskAnnApproxRetrievedDocs
+        ExactDocs      = $_.diskAnnExactRetrievedDocs
+        'Overlap%'     = $_.diskAnnApproxVsExactOverlapPct
+    }
+}
+Write-Host "`n======== QUERY-ONLY: Spherical vs Product ($NQuery queries, warmup on) ========" -ForegroundColor Cyan
+$rows | Format-Table -AutoSize
+$rows | Export-Csv -Path (Join-Path $outDir "queryonly-results.csv") -NoTypeInformation
+$results | ConvertTo-Json -Depth 6 | Set-Content -Path (Join-Path $outDir "queryonly-results.json")
+Write-Host "Wrote queryonly-results.csv / .json"

--- a/perf/run_r3.ps1
+++ b/perf/run_r3.ps1
@@ -1,0 +1,277 @@
+<#
+  run_r3.ps1 - Round-3 vector-index benchmark orchestrator.
+
+  Goal: 3 Product + 3 Spherical collections per account (12 total for two accounts).
+    - Product collections: explicit quantizationByteSize=192.
+    - Spherical collections: no byteSize override (feature-gated, service default).
+    - Exactly 1 physical partition @ 10,000 RU. Achieved with the PROVEN recipe:
+        create @400 RU (suite, data-plane) -> scale to 10000 (control-plane az) -> 1 partition.
+    - Verify topology BEFORE ingesting (pcheck feedRanges==1). On mismatch: ingest anyway,
+      but record actual topology (user: ingest_anyway).
+    - 1,000,000 wiki-cohere vectors + 500 measured queries with warmup.
+
+  Methodology (per user's answers):
+    - Both configured accounts run concurrently.
+    - queryModel = concurrent_ingest_serial_query : ingest may overlap, but queries run
+      one container at a time per account for clean latency (concurrent queries were shown
+      to inflate latency ~20x on the same account). We ingest SERIALLY within an account
+      (2 concurrent ingests total, one per account) for reliability, and query SERIALLY
+      within an account, with the two accounts proceeding in parallel.
+    - mismatchHandling = ingest_anyway.
+
+  Throughput mechanics (important):
+    - Suite create uses cosmosContainerRUInitial for CreateContainerIfNotExists.
+    - WikiCohere ctor unconditionally calls ReplaceFinalThroughput(10000) (data-plane,
+      async void). To keep BOTH accounts on the identical proven recipe we pass RUFinal=400
+      during CREATE so that call no-ops. Real scaling is done via control-plane az afterwards.
+
+  Phases: create | ingest | query | report | all
+#>
+param(
+  [ValidateSet("all","create","ingest","query","report")]
+  [string]$Phase = "all",
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+  [Parameter(Mandatory = $true)]
+  [string]$AccountConfigPath,
+  [int[]]$Runs = @(1,2,3),
+  [string[]]$Quantizers = @("product","spherical"),
+  [string[]]$Accounts = @("account1","account2"),
+  [int]$SliceCount = 1000000,
+  [int]$NumQueries = 500,
+  [int]$NumWarmupQueries = 100,
+  [int]$ProductByteSize = 192
+)
+
+$ErrorActionPreference = "Stop"
+$root   = (Resolve-Path $RepoRoot).Path
+$exe    = "$root\bin\Release\net8.0\win-x64\VectorIndexScenarioSuite.exe"
+$pcheck = "$root\perf\pcheck\bin\Release\net8.0\pcheck.dll"
+$db     = "vector-benchmarking"
+$outDir = "$root\perf\r3"
+$logDir = "$outDir\logs"
+$track  = "$outDir\run_tracking_r3.txt"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+if (-not (Test-Path $AccountConfigPath)) {
+  throw "Account config not found: $AccountConfigPath"
+}
+
+$AccountCfg = @{}
+$accountConfig = Get-Content $AccountConfigPath -Raw | ConvertFrom-Json
+foreach ($property in $accountConfig.PSObject.Properties) {
+  $AccountCfg[$property.Name] = @{
+    endpoint = $property.Value.endpoint
+    account  = $property.Value.account
+    rg       = $property.Value.resourceGroup
+  }
+}
+foreach ($accountAlias in $Accounts) {
+  if (-not $AccountCfg.ContainsKey($accountAlias)) {
+    throw "Account alias '$accountAlias' is missing from $AccountConfigPath"
+  }
+}
+
+function Log($msg) {
+  $line = "[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date), $msg
+  Write-Host $line
+  Add-Content -Path $track -Value $line
+}
+
+function Container-Name($acct,$q,$n) { "r3-$acct-$q-run$n" }
+
+# Build the full matrix of work items.
+function Get-Matrix {
+  $items = @()
+  foreach ($acct in $Accounts) {
+    foreach ($q in $Quantizers) {
+      foreach ($n in $Runs) {
+        $items += [pscustomobject]@{
+          Account = $acct; Quantizer = $q; Run = $n
+          Container = (Container-Name $acct $q $n)
+          ByteSize  = ($(if ($q -eq "product") { "$ProductByteSize" } else { "" }))
+          Endpoint  = $AccountCfg[$acct].endpoint
+          AccountName = $AccountCfg[$acct].account
+          Rg        = $AccountCfg[$acct].rg
+        }
+      }
+    }
+  }
+  return $items
+}
+
+# Invoke the suite exe with config overrides; pipe empty stdin (unconditional Console.ReadLine).
+function Invoke-Suite {
+  param([hashtable]$Cfg, [string]$LogPath)
+  $args = @()
+  foreach ($k in $Cfg.Keys) { $args += "--$k=$($Cfg[$k])" }
+  "" | & $exe @args *>&1 | Tee-Object -FilePath $LogPath | Out-Null
+  return Get-Content $LogPath
+}
+
+# ---------------- CREATE (+ scale + verify) ----------------
+function Do-Create {
+  Log "=== CREATE PHASE ==="
+  # Ensure DB exists on each account (control-plane; idempotent).
+  foreach ($acct in $Accounts) {
+    $c = $AccountCfg[$acct]
+    Log "Ensuring DB '$db' on $acct ..."
+    az cosmosdb sql database create --account-name $c.account --resource-group $c.rg --name $db -o none 2>$null
+  }
+  foreach ($it in (Get-Matrix)) {
+    $cn = $it.Container
+    Log "CREATE $cn (acct=$($it.Account) q=$($it.Quantizer) byteSize='$($it.ByteSize)')"
+    $cfg = @{
+      "AppSettings:accountEndpoint"                 = $it.Endpoint
+      "AppSettings:useAADAuth"                       = "true"
+      "AppSettings:cosmosDatabaseId"                 = $db
+      "AppSettings:cosmosContainerId"                = $cn
+      "AppSettings:deleteContainerOnStart"           = "true"
+      "AppSettings:cosmosContainerRUInitial"         = "400"
+      "AppSettings:cosmosContainerRUFinal"           = "400"   # no-op suite scale; we scale via control-plane
+      "AppSettings:scenario:sliceCount"              = "$SliceCount"
+      "AppSettings:scenario:runIngestion"            = "false"
+      "AppSettings:scenario:runQuery"                = "false"
+      "AppSettings:scenario:quantizerType"           = $it.Quantizer
+      "AppSettings:scenario:quantizationByteSize"    = $it.ByteSize
+    }
+    Invoke-Suite -Cfg $cfg -LogPath "$logDir\create-$cn.log" | Out-Null
+
+    # Scale to 10000 via control-plane.
+    Log "SCALE $cn -> 10000 (control-plane)"
+    az cosmosdb sql container throughput update --account-name $it.AccountName --resource-group $it.Rg --database-name $db --name $cn --throughput 10000 -o none 2>$null
+
+    # Verify topology (authoritative feed-range count) BEFORE ingest.
+    Start-Sleep 3
+    $pj = (dotnet $pcheck $it.Endpoint $db $cn 2>&1 | Select-String "PCHECK_JSON").ToString()
+    $tp = (az cosmosdb sql container throughput show --account-name $it.AccountName --resource-group $it.Rg --database-name $db --name $cn --query "resource.throughput" -o tsv 2>$null)
+    if ($pj) {
+      $fr = ([regex]'"feedRanges":(\d+)').Match($pj).Groups[1].Value
+      Log "VERIFY $cn feedRanges=$fr throughput=$tp $(if($fr -ne '1'){'*** MISMATCH: not 1 partition (ingesting anyway) ***'})"
+    } else {
+      Log "VERIFY $cn pcheck FAILED (throughput=$tp) - ingesting anyway"
+    }
+  }
+  Log "=== CREATE PHASE DONE ==="
+}
+
+# ---------------- INGEST (all containers concurrent) ----------------
+# Each container has its own independent 10,000-RU single partition, so ingests do
+# not share RU; the client (32 cores, network/RU-bound) is not the bottleneck. Run all
+# 12 concurrently for ~2-3h wall-clock instead of ~12h serial.
+function Do-Ingest {
+  Log "=== INGEST PHASE (all containers concurrent) ==="
+  $jobs = @()
+  foreach ($it in (Get-Matrix)) {
+    $cn = $it.Container
+    Log "INGEST START $cn"
+    $jobs += Start-Job -Name "ingest-$cn" -ScriptBlock {
+      param($it,$exe,$db,$logDir,$track,$SliceCount)
+      function JLog($m,$track){ $l="[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date),$m; Add-Content -Path $track -Value $l }
+      $cn = $it.Container
+      $args = @(
+        "--AppSettings:accountEndpoint=$($it.Endpoint)",
+        "--AppSettings:useAADAuth=true",
+        "--AppSettings:cosmosDatabaseId=$db",
+        "--AppSettings:cosmosContainerId=$cn",
+        "--AppSettings:deleteContainerOnStart=false",
+        "--AppSettings:cosmosContainerRUInitial=0",
+        "--AppSettings:cosmosContainerRUFinal=0",
+        "--AppSettings:scenario:sliceCount=$SliceCount",
+        "--AppSettings:scenario:runIngestion=true",
+        "--AppSettings:scenario:runQuery=false",
+        "--AppSettings:scenario:startVectorId=0",
+        "--AppSettings:scenario:endVectorId=0",
+        "--AppSettings:scenario:quantizerType=$($it.Quantizer)",
+        "--AppSettings:scenario:quantizationByteSize=$($it.ByteSize)",
+        "--AppSettings:scenario:catchupTimeoutMinutes=45"
+      )
+      "" | & $exe @args *>&1 | Tee-Object -FilePath "$logDir\ingest-$cn.log" | Out-Null
+      $perf = Select-String -Path "$logDir\ingest-$cn.log" -Pattern "\[PERF\]|Ingestion of|catch-up took" | ForEach-Object { $_.Line }
+      JLog "INGEST DONE $cn :: $($perf -join ' | ')" $track
+    } -ArgumentList $it,$exe,$db,$logDir,$track,$SliceCount
+  }
+  Log "All $($jobs.Count) ingest jobs started. Waiting..."
+  $jobs | Wait-Job | Out-Null
+  $jobs | Receive-Job
+  $jobs | Remove-Job
+  Log "=== INGEST PHASE DONE ==="
+}
+
+# ---------------- QUERY (serial within account, accounts parallel) ----------------
+function Do-Query {
+  Log "=== QUERY PHASE (serial within account, accounts parallel) ==="
+  $jobs = @()
+  foreach ($acct in $Accounts) {
+    $items = (Get-Matrix) | Where-Object { $_.Account -eq $acct }
+    $jobs += Start-Job -Name "query-$acct" -ScriptBlock {
+      param($items,$exe,$db,$logDir,$track,$SliceCount,$NumQueries,$NumWarmupQueries)
+      function JLog($m,$track){ $l="[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date),$m; Add-Content -Path $track -Value $l; Write-Host $l }
+      foreach ($it in $items) {
+        $cn = $it.Container
+        JLog "QUERY START $cn" $track
+        $args = @(
+          "--AppSettings:accountEndpoint=$($it.Endpoint)",
+          "--AppSettings:useAADAuth=true",
+          "--AppSettings:cosmosDatabaseId=$db",
+          "--AppSettings:cosmosContainerId=$cn",
+          "--AppSettings:deleteContainerOnStart=false",
+          "--AppSettings:cosmosContainerRUInitial=0",
+          "--AppSettings:cosmosContainerRUFinal=0",
+          "--AppSettings:scenario:sliceCount=$SliceCount",
+          "--AppSettings:scenario:runIngestion=false",
+          "--AppSettings:scenario:runQuery=true",
+          "--AppSettings:scenario:numQueries=$NumQueries",
+          "--AppSettings:scenario:warmup:enabled=true",
+          "--AppSettings:scenario:warmup:numWarmupQueries=$NumWarmupQueries",
+          "--AppSettings:scenario:computeRecall=true",
+          "--AppSettings:scenario:computeLatencyAndRUStats=true",
+          "--AppSettings:scenario:quantizerType=$($it.Quantizer)",
+          "--AppSettings:scenario:quantizationByteSize=$($it.ByteSize)",
+          "--AppSettings:scenario:datasetLabel=$cn"
+        )
+        "" | & $exe @args *>&1 | Tee-Object -FilePath "$logDir\query-$cn.log" | Out-Null
+        $rj = Select-String -Path "$logDir\query-$cn.log" -Pattern "RESULT_JSON:" | Select-Object -Last 1 | ForEach-Object { $_.Line }
+        $qc = Select-String -Path "$logDir\query-$cn.log" -Pattern "QUANTIZER-CHECK" | ForEach-Object { $_.Line }
+        JLog "QUERY DONE $cn :: $rj" $track
+        if ($qc) { JLog "QUERY QCHECK $cn :: $($qc -join ' || ')" $track }
+      }
+    } -ArgumentList $items,$exe,$db,$logDir,$track,$SliceCount,$NumQueries,$NumWarmupQueries
+  }
+  Log "Query jobs started: $($jobs.Name -join ', '). Waiting..."
+  $jobs | Wait-Job | Out-Null
+  $jobs | Receive-Job
+  $jobs | Remove-Job
+  Log "=== QUERY PHASE DONE ==="
+}
+
+# ---------------- REPORT ----------------
+function Do-Report {
+  Log "=== REPORT ==="
+  $rows = @()
+  foreach ($it in (Get-Matrix)) {
+    $cn = $it.Container
+    $lp = "$logDir\query-$cn.log"
+    if (-not (Test-Path $lp)) { continue }
+    $rj = Select-String -Path $lp -Pattern "RESULT_JSON:" | Select-Object -Last 1 | ForEach-Object { $_.Line -replace '^.*RESULT_JSON:\s*','' }
+    if ($rj) {
+      try { $rows += ($rj | ConvertFrom-Json) } catch { Log "REPORT parse failed for $cn" }
+    }
+  }
+  $reportPath = "$outDir\report_r3.csv"
+  $rows | Select-Object container, quantizerType, effectiveQuantizerType, ingestedVectors,
+      @{n='recall10';e={$_.recall.'10'}}, avgQueryServerLatencyMs, p50QueryServerLatencyMs,
+      p99QueryServerLatencyMs, avgQueryClientLatencyMs, avgQueryRU, diskAnnUsed |
+    Sort-Object container | Format-Table -AutoSize | Out-String -Width 400 | Tee-Object -FilePath "$outDir\report_r3.txt"
+  $rows | Export-Csv -Path $reportPath -NoTypeInformation
+  Log "Report written: $reportPath"
+}
+
+Log "############ run_r3 START phase=$Phase accounts=$($Accounts -join ',') quantizers=$($Quantizers -join ',') runs=$($Runs -join ',') ############"
+switch ($Phase) {
+  "create" { Do-Create }
+  "ingest" { Do-Ingest }
+  "query"  { Do-Query }
+  "report" { Do-Report }
+  "all"    { Do-Create; Do-Ingest; Do-Query; Do-Report }
+}
+Log "############ run_r3 END phase=$Phase ############"

--- a/perf/run_r4.ps1
+++ b/perf/run_r4.ps1
@@ -1,0 +1,306 @@
+<#
+  run_r4.ps1 - Round-4 "index-AFTER-ingest" vector-index benchmark orchestrator.
+
+  Same matrix/params as r3 (3 Product + 3 Spherical per account, 12 total;
+  1 partition @ 10,000 RU; 1,000,000 wiki-cohere vectors; 500 queries + 100 warmup;
+  Product byteSize=192; Spherical service default) EXCEPT the index timing:
+
+    r3: container created WITH the DiskANN vector index -> index builds incrementally
+        DURING ingest.
+    r4: container created WITHOUT any vector index (embedding policy only, which is
+        immutable/required) -> ingest all 1M docs -> THEN add the DiskANN vector index
+        via ReplaceContainer -> the graph builds as a FULL build over existing data.
+
+  Phases: create | ingest | addindex | query | report | all
+    create   : idxctl create-noindex @400 -> az scale 10000 -> pcheck feedRanges==1.
+    ingest   : suite ingest 1M (all 12 concurrent). catchupTimeoutMinutes=1 (no index yet;
+               the suite's catch-up probe can't engage, so keep it short).
+    addindex : idxctl add-index (ReplaceContainer, Product->192 / Spherical->default),
+               then WAIT for the DiskANN graph to build over existing data by polling a
+               tiny suite query until diskAnnUsed==true (records post-ingest build wall-clock).
+    query    : suite query 500 + 100 warmup + recall + latency/RU (serial per account,
+               accounts parallel) -- identical to r3.
+    report   : parse RESULT_JSON -> CSV + txt.
+
+  Smoke-tested end-to-end (see findings id 43): the backend DOES allow adding a DiskANN
+  vector index via ReplaceContainer on a populated container.
+#>
+param(
+  [ValidateSet("all","create","ingest","addindex","query","report")]
+  [string]$Phase = "all",
+  [string]$RepoRoot = (Split-Path -Parent $PSScriptRoot),
+  [Parameter(Mandatory = $true)]
+  [string]$AccountConfigPath,
+  [int[]]$Runs = @(1,2,3),
+  [string[]]$Quantizers = @("product","spherical"),
+  [string[]]$Accounts = @("account1","account2"),
+  [int]$SliceCount = 1000000,
+  [int]$NumQueries = 500,
+  [int]$NumWarmupQueries = 100,
+  [int]$ProductByteSize = 192,
+  [int]$BuildWaitMaxMinutes = 180
+)
+
+$ErrorActionPreference = "Stop"
+$root   = (Resolve-Path $RepoRoot).Path
+$exe    = "$root\bin\Release\net8.0\win-x64\VectorIndexScenarioSuite.exe"
+$pcheck = "$root\perf\pcheck\bin\Release\net8.0\pcheck.dll"
+$idxctl = "$root\perf\idxctl\bin\Release\net8.0\idxctl.dll"
+$db     = "vector-benchmarking"
+$outDir = "$root\perf\r4"
+$logDir = "$outDir\logs"
+$track  = "$outDir\run_tracking_r4.txt"
+New-Item -ItemType Directory -Force -Path $logDir | Out-Null
+
+if (-not (Test-Path $AccountConfigPath)) {
+  throw "Account config not found: $AccountConfigPath"
+}
+
+$AccountCfg = @{}
+$accountConfig = Get-Content $AccountConfigPath -Raw | ConvertFrom-Json
+foreach ($property in $accountConfig.PSObject.Properties) {
+  $AccountCfg[$property.Name] = @{
+    endpoint = $property.Value.endpoint
+    account  = $property.Value.account
+    rg       = $property.Value.resourceGroup
+  }
+}
+foreach ($accountAlias in $Accounts) {
+  if (-not $AccountCfg.ContainsKey($accountAlias)) {
+    throw "Account alias '$accountAlias' is missing from $AccountConfigPath"
+  }
+}
+
+function Log($msg) {
+  $line = "[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date), $msg
+  Write-Host $line
+  Add-Content -Path $track -Value $line
+}
+
+function Container-Name($acct,$q,$n) { "r4-$acct-$q-run$n" }
+
+function Get-Matrix {
+  $items = @()
+  foreach ($acct in $Accounts) {
+    foreach ($q in $Quantizers) {
+      foreach ($n in $Runs) {
+        $items += [pscustomobject]@{
+          Account = $acct; Quantizer = $q; Run = $n
+          Container = (Container-Name $acct $q $n)
+          ByteSize  = ($(if ($q -eq "product") { "$ProductByteSize" } else { "" }))
+          Endpoint  = $AccountCfg[$acct].endpoint
+          AccountName = $AccountCfg[$acct].account
+          Rg        = $AccountCfg[$acct].rg
+        }
+      }
+    }
+  }
+  return $items
+}
+
+# ---------------- CREATE (no vector index) + scale + verify ----------------
+function Do-Create {
+  Log "=== CREATE PHASE (no vector index) ==="
+  foreach ($acct in $Accounts) {
+    $c = $AccountCfg[$acct]
+    Log "Ensuring DB '$db' on $acct ..."
+    az cosmosdb sql database create --account-name $c.account --resource-group $c.rg --name $db -o none 2>$null
+  }
+  foreach ($it in (Get-Matrix)) {
+    $cn = $it.Container
+    # Clean start: delete any pre-existing container (idxctl create-noindex is create-if-not-exists).
+    Log "DELETE (if exists) $cn"
+    az cosmosdb sql container delete --account-name $it.AccountName --resource-group $it.Rg --database-name $db --name $cn --yes -o none 2>$null
+
+    Log "CREATE-NOINDEX $cn (acct=$($it.Account) q=$($it.Quantizer))"
+    dotnet $idxctl create-noindex $it.Endpoint $db $cn 400 2>&1 | ForEach-Object { if ($_ -match "IDXCTL_JSON") { Log "  $_" } }
+
+    Log "SCALE $cn -> 10000 (control-plane)"
+    az cosmosdb sql container throughput update --account-name $it.AccountName --resource-group $it.Rg --database-name $db --name $cn --throughput 10000 -o none 2>$null
+
+    Start-Sleep 3
+    $pj = (dotnet $pcheck $it.Endpoint $db $cn 2>&1 | Select-String "PCHECK_JSON").ToString()
+    $tp = (az cosmosdb sql container throughput show --account-name $it.AccountName --resource-group $it.Rg --database-name $db --name $cn --query "resource.throughput" -o tsv 2>$null)
+    if ($pj) {
+      $fr = ([regex]'"feedRanges":(\d+)').Match($pj).Groups[1].Value
+      Log "VERIFY $cn feedRanges=$fr throughput=$tp $(if($fr -ne '1'){'*** MISMATCH: not 1 partition (ingesting anyway) ***'})"
+    } else {
+      Log "VERIFY $cn pcheck FAILED (throughput=$tp) - ingesting anyway"
+    }
+  }
+  Log "=== CREATE PHASE DONE ==="
+}
+
+# ---------------- INGEST (all containers concurrent, no index present) ----------------
+function Do-Ingest {
+  Log "=== INGEST PHASE (all containers concurrent, no index) ==="
+  $jobs = @()
+  foreach ($it in (Get-Matrix)) {
+    $cn = $it.Container
+    Log "INGEST START $cn"
+    $jobs += Start-Job -Name "ingest-$cn" -ScriptBlock {
+      param($it,$exe,$db,$logDir,$track,$SliceCount)
+      function JLog($m,$track){ $l="[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date),$m; Add-Content -Path $track -Value $l }
+      $cn = $it.Container
+      $args = @(
+        "--AppSettings:accountEndpoint=$($it.Endpoint)",
+        "--AppSettings:useAADAuth=true",
+        "--AppSettings:cosmosDatabaseId=$db",
+        "--AppSettings:cosmosContainerId=$cn",
+        "--AppSettings:deleteContainerOnStart=false",
+        "--AppSettings:cosmosContainerRUInitial=0",
+        "--AppSettings:cosmosContainerRUFinal=0",
+        "--AppSettings:scenario:sliceCount=$SliceCount",
+        "--AppSettings:scenario:runIngestion=true",
+        "--AppSettings:scenario:runQuery=false",
+        "--AppSettings:scenario:startVectorId=0",
+        "--AppSettings:scenario:endVectorId=0",
+        "--AppSettings:scenario:quantizerType=$($it.Quantizer)",
+        "--AppSettings:scenario:quantizationByteSize=$($it.ByteSize)",
+        "--AppSettings:scenario:catchupTimeoutMinutes=1"
+      )
+      "" | & $exe @args *>&1 | Tee-Object -FilePath "$logDir\ingest-$cn.log" | Out-Null
+      $perf = Select-String -Path "$logDir\ingest-$cn.log" -Pattern "\[PERF\]|Ingestion of" | ForEach-Object { $_.Line }
+      JLog "INGEST DONE $cn :: $($perf -join ' | ')" $track
+    } -ArgumentList $it,$exe,$db,$logDir,$track,$SliceCount
+  }
+  Log "All $($jobs.Count) ingest jobs started. Waiting..."
+  $jobs | Wait-Job | Out-Null
+  $jobs | Receive-Job
+  $jobs | Remove-Job
+  Log "=== INGEST PHASE DONE ==="
+}
+
+# ---------------- ADD-INDEX (post-ingest) + wait for full graph build ----------------
+function Do-AddIndex {
+  Log "=== ADDINDEX PHASE (add DiskANN via ReplaceContainer, wait for build) ==="
+  $jobs = @()
+  foreach ($it in (Get-Matrix)) {
+    $cn = $it.Container
+    Log "ADDINDEX START $cn (q=$($it.Quantizer) byteSize='$($it.ByteSize)')"
+    $jobs += Start-Job -Name "addidx-$cn" -ScriptBlock {
+      param($it,$exe,$idxctl,$db,$logDir,$track,$SliceCount,$BuildWaitMaxMinutes)
+      function JLog($m,$track){ $l="[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date),$m; Add-Content -Path $track -Value $l }
+      $cn = $it.Container
+      $t0 = Get-Date
+      # 1) Add the DiskANN vector index over existing data.
+      $addOut = dotnet $idxctl add-index $it.Endpoint $db $cn $it.Quantizer $it.ByteSize 2>&1
+      $addOut | Set-Content "$logDir\addindex-$cn.log"
+      $addJson = ($addOut | Select-String "IDXCTL_JSON").ToString()
+      JLog "ADDINDEX REPLACED $cn :: $addJson" $track
+
+      # 2) Poll a tiny suite query until DiskANN engages (graph built over existing docs).
+      $deadline = $t0.AddMinutes($BuildWaitMaxMinutes)
+      $engaged = $false
+      while ((Get-Date) -lt $deadline) {
+        Start-Sleep 60
+        $qargs = @(
+          "--AppSettings:accountEndpoint=$($it.Endpoint)","--AppSettings:useAADAuth=true",
+          "--AppSettings:cosmosDatabaseId=$db","--AppSettings:cosmosContainerId=$cn",
+          "--AppSettings:deleteContainerOnStart=false",
+          "--AppSettings:cosmosContainerRUInitial=0","--AppSettings:cosmosContainerRUFinal=0",
+          "--AppSettings:scenario:sliceCount=$SliceCount",
+          "--AppSettings:scenario:runIngestion=false","--AppSettings:scenario:runQuery=true",
+          "--AppSettings:scenario:numQueries=3",
+          "--AppSettings:scenario:warmup:enabled=false",
+          "--AppSettings:scenario:computeRecall=false","--AppSettings:scenario:computeLatencyAndRUStats=true",
+          "--AppSettings:scenario:quantizerType=$($it.Quantizer)","--AppSettings:scenario:quantizationByteSize=$($it.ByteSize)",
+          "--AppSettings:scenario:datasetLabel=$cn-probe"
+        )
+        "" | & $exe @qargs *>&1 | Tee-Object -FilePath "$logDir\addindex-probe-$cn.log" | Out-Null
+        $rj = Select-String -Path "$logDir\addindex-probe-$cn.log" -Pattern "RESULT_JSON:" | Select-Object -Last 1 | ForEach-Object { $_.Line }
+        $used = $false
+        if ($rj -match '"diskAnnUsed":(true|false)') { $used = ($Matches[1] -eq "true") }
+        $elapsed = [int]((Get-Date) - $t0).TotalSeconds
+        JLog "ADDINDEX PROBE $cn t=${elapsed}s diskAnnUsed=$used" $track
+        if ($used) { $engaged = $true; JLog "ADDINDEX BUILT $cn :: buildWaitSec=$elapsed" $track; break }
+      }
+      if (-not $engaged) { JLog "ADDINDEX TIMEOUT $cn :: DiskANN not engaged within $BuildWaitMaxMinutes min" $track }
+    } -ArgumentList $it,$exe,$idxctl,$db,$logDir,$track,$SliceCount,$BuildWaitMaxMinutes
+  }
+  Log "All $($jobs.Count) addindex jobs started. Waiting..."
+  $jobs | Wait-Job | Out-Null
+  $jobs | Receive-Job
+  $jobs | Remove-Job
+  Log "=== ADDINDEX PHASE DONE ==="
+}
+
+# ---------------- QUERY (serial within account, accounts parallel) ----------------
+function Do-Query {
+  Log "=== QUERY PHASE (serial within account, accounts parallel) ==="
+  $jobs = @()
+  foreach ($acct in $Accounts) {
+    $items = (Get-Matrix) | Where-Object { $_.Account -eq $acct }
+    $jobs += Start-Job -Name "query-$acct" -ScriptBlock {
+      param($items,$exe,$db,$logDir,$track,$SliceCount,$NumQueries,$NumWarmupQueries)
+      function JLog($m,$track){ $l="[{0:yyyy-MM-dd HH:mm:ss}] {1}" -f (Get-Date),$m; Add-Content -Path $track -Value $l; Write-Host $l }
+      foreach ($it in $items) {
+        $cn = $it.Container
+        JLog "QUERY START $cn" $track
+        $args = @(
+          "--AppSettings:accountEndpoint=$($it.Endpoint)",
+          "--AppSettings:useAADAuth=true",
+          "--AppSettings:cosmosDatabaseId=$db",
+          "--AppSettings:cosmosContainerId=$cn",
+          "--AppSettings:deleteContainerOnStart=false",
+          "--AppSettings:cosmosContainerRUInitial=0",
+          "--AppSettings:cosmosContainerRUFinal=0",
+          "--AppSettings:scenario:sliceCount=$SliceCount",
+          "--AppSettings:scenario:runIngestion=false",
+          "--AppSettings:scenario:runQuery=true",
+          "--AppSettings:scenario:numQueries=$NumQueries",
+          "--AppSettings:scenario:warmup:enabled=true",
+          "--AppSettings:scenario:warmup:numWarmupQueries=$NumWarmupQueries",
+          "--AppSettings:scenario:computeRecall=true",
+          "--AppSettings:scenario:computeLatencyAndRUStats=true",
+          "--AppSettings:scenario:quantizerType=$($it.Quantizer)",
+          "--AppSettings:scenario:quantizationByteSize=$($it.ByteSize)",
+          "--AppSettings:scenario:datasetLabel=$cn"
+        )
+        "" | & $exe @args *>&1 | Tee-Object -FilePath "$logDir\query-$cn.log" | Out-Null
+        $rj = Select-String -Path "$logDir\query-$cn.log" -Pattern "RESULT_JSON:" | Select-Object -Last 1 | ForEach-Object { $_.Line }
+        $qc = Select-String -Path "$logDir\query-$cn.log" -Pattern "QUANTIZER-CHECK" | ForEach-Object { $_.Line }
+        JLog "QUERY DONE $cn :: $rj" $track
+        if ($qc) { JLog "QUERY QCHECK $cn :: $($qc -join ' || ')" $track }
+      }
+    } -ArgumentList $items,$exe,$db,$logDir,$track,$SliceCount,$NumQueries,$NumWarmupQueries
+  }
+  Log "Query jobs started: $($jobs.Name -join ', '). Waiting..."
+  $jobs | Wait-Job | Out-Null
+  $jobs | Receive-Job
+  $jobs | Remove-Job
+  Log "=== QUERY PHASE DONE ==="
+}
+
+# ---------------- REPORT ----------------
+function Do-Report {
+  Log "=== REPORT ==="
+  $rows = @()
+  foreach ($it in (Get-Matrix)) {
+    $cn = $it.Container
+    $lp = "$logDir\query-$cn.log"
+    if (-not (Test-Path $lp)) { continue }
+    $rj = Select-String -Path $lp -Pattern "RESULT_JSON:" | Select-Object -Last 1 | ForEach-Object { $_.Line -replace '^.*RESULT_JSON:\s*','' }
+    if ($rj) {
+      try { $rows += ($rj | ConvertFrom-Json) } catch { Log "REPORT parse failed for $cn" }
+    }
+  }
+  $reportPath = "$outDir\report_r4.csv"
+  $rows | Select-Object container, quantizerType, effectiveQuantizerType, ingestedVectors,
+      @{n='recall10';e={$_.recall.'10'}}, avgQueryServerLatencyMs, p50QueryServerLatencyMs,
+      p99QueryServerLatencyMs, avgQueryClientLatencyMs, avgQueryRU, diskAnnUsed |
+    Sort-Object container | Format-Table -AutoSize | Out-String -Width 400 | Tee-Object -FilePath "$outDir\report_r4.txt"
+  $rows | Export-Csv -Path $reportPath -NoTypeInformation
+  Log "Report written: $reportPath"
+}
+
+Log "############ run_r4 START phase=$Phase accounts=$($Accounts -join ',') quantizers=$($Quantizers -join ',') runs=$($Runs -join ',') ############"
+switch ($Phase) {
+  "create"   { Do-Create }
+  "ingest"   { Do-Ingest }
+  "addindex" { Do-AddIndex }
+  "query"    { Do-Query }
+  "report"   { Do-Report }
+  "all"      { Do-Create; Do-Ingest; Do-AddIndex; Do-Query; Do-Report }
+}
+Log "############ run_r4 END phase=$Phase ############"

--- a/src/EmbeddingScenarioBase.cs
+++ b/src/EmbeddingScenarioBase.cs
@@ -34,6 +34,19 @@ namespace VectorIndexScenarioSuite
 
         protected ScenarioMetrics ingestionMetrics;
 
+        /* Perf comparison instrumentation (spherical vs product quantizer). */
+        protected double ingestionDurationMs = 0;
+        protected double indexCatchupDurationMs = 0;
+        protected double queryPhaseDurationMs = 0;
+        protected bool diskAnnValidationRan = false;
+        protected bool diskAnnUsed = false;
+        protected long diskAnnApproxRetrievedDocs = 0;
+        protected long diskAnnExactRetrievedDocs = 0;
+        protected double diskAnnApproxRU = 0;
+        protected double diskAnnExactRU = 0;
+        protected double diskAnnApproxVsExactOverlap = 0;
+        protected string effectiveQuantizerType = "";
+
         public EmbeddingScenarioBase(IConfiguration configurations, int throughPut) : 
             base(configurations, throughPut)
         {
@@ -67,6 +80,15 @@ namespace VectorIndexScenarioSuite
                 Path = this.EmbeddingPath,
                 Type = VectorIndexType.DiskANN,
             };
+            string quantizerTypeSetting = this.Configurations["AppSettings:scenario:quantizerType"];
+            if (!string.IsNullOrEmpty(quantizerTypeSetting))
+            {
+                if (!Enum.TryParse<QuantizerType>(quantizerTypeSetting, ignoreCase: true, out var quantizerType))
+                {
+                    throw new ArgumentException($"Invalid quantizerType '{quantizerTypeSetting}'. Valid values: {string.Join(", ", Enum.GetNames(typeof(QuantizerType)))}.");
+                }
+                vectorIndexPath.QuantizerType = quantizerType;
+            }
             if (!string.IsNullOrEmpty(this.Configurations["AppSettings:scenario:quantizationByteSize"]))
             {
                 var quantizationByteSize = Convert.ToInt32(this.Configurations["AppSettings:scenario:quantizationByteSize"]);
@@ -342,7 +364,7 @@ namespace VectorIndexScenarioSuite
             }
         }
 
-        private QueryDefinition ConstructQueryDefinition(int K, T[] queryVector, string whereClause)
+        private QueryDefinition ConstructQueryDefinition(int K, T[] queryVector, string whereClause, bool exact = false)
         {
             int searchListSizeMultiplier = Convert.ToInt32(this.Configurations["AppSettings:scenario:searchListSizeMultiplier"]);
 
@@ -353,10 +375,135 @@ namespace VectorIndexScenarioSuite
             }
             // empty json object for using default value if multiplier is 0
             string obj_expr = searchListSizeMultiplier == 0 ? "{}" : $"{{ 'searchListSizeMultiplier': {searchListSizeMultiplier} }}";
-            string queryText = $"SELECT TOP {K} c.id, VectorDistance(c.{this.EmbeddingColumn}, @vectorEmbedding) AS similarityScore " +
-                $"FROM c {whereClause} ORDER BY VectorDistance(c.{this.EmbeddingColumn}, @vectorEmbedding, false, {obj_expr})";
+            string exactExpr = exact ? "true" : "false";
+            string queryText = $"SELECT TOP {K} c.id, VectorDistance(c.{this.EmbeddingColumn}, @vectorEmbedding) AS similarityScore " +
+                $"FROM c {whereClause} ORDER BY VectorDistance(c.{this.EmbeddingColumn}, @vectorEmbedding, {exactExpr}, {obj_expr})";
             return new QueryDefinition(queryText).WithParameter("@vectorEmbedding", serializedVector);
 
+        }
+
+        /// <summary>
+        /// Validates that the DiskANN vector index is actually used for search. Runs the same
+        /// query as an index-based (approximate) search and as a brute-force (exact) search, then
+        /// compares retrieved-document counts and RU charge. When the index is used, the approximate
+        /// search retrieves far fewer documents and costs far fewer RUs than the full scan.
+        /// </summary>
+        private async Task ValidateDiskANNUsageAsync(string dataPath)
+        {
+            const int validationK = 10;
+            this.diskAnnValidationRan = true;
+
+            await foreach ((int vectorId, T[] vector, string whereClause) in
+                JsonDocumentFactory<T>.GetQueryAsync(dataPath, 0 /* startVectorId */, 1 /* single query */, this.IsFilterSearch))
+            {
+                (List<string> approxIds, long approxDocs, double approxRU) = await RunSingleQueryWithMetrics(validationK, vector, whereClause, exact: false);
+                (List<string> exactIds, long exactDocs, double exactRU) = await RunSingleQueryWithMetrics(validationK, vector, whereClause, exact: true);
+
+                this.diskAnnApproxRetrievedDocs = approxDocs;
+                this.diskAnnExactRetrievedDocs = exactDocs;
+                this.diskAnnApproxRU = approxRU;
+                this.diskAnnExactRU = exactRU;
+
+                int overlap = approxIds.Intersect(exactIds).Count();
+                this.diskAnnApproxVsExactOverlap = exactIds.Count == 0 ? 0 : (overlap * 100.0 / exactIds.Count);
+
+                // Heuristic: index is used when the approximate scan touches strictly fewer docs than
+                // the exact (brute-force) scan AND costs fewer RUs. (When retrieved-doc counts are not
+                // surfaced, fall back to the RU comparison alone.)
+                bool fewerDocs = (approxDocs > 0 && exactDocs > 0) ? approxDocs < exactDocs : true;
+                bool cheaper = approxRU < exactRU;
+                this.diskAnnUsed = fewerDocs && cheaper;
+
+                Console.WriteLine("[DISKANN-VALIDATION] " +
+                    $"approx(index): retrievedDocs={approxDocs}, RU={approxRU:F2} | " +
+                    $"exact(scan): retrievedDocs={exactDocs}, RU={exactRU:F2} | " +
+                    $"top{validationK} overlap={this.diskAnnApproxVsExactOverlap:F1}% | " +
+                    $"DiskANN used={this.diskAnnUsed}");
+                break;
+            }
+        }
+
+        private async Task<(List<string> ids, long retrievedDocs, double ru)> RunSingleQueryWithMetrics(
+            int K, T[] vector, string whereClause, bool exact)
+        {
+            var queryDefinition = ConstructQueryDefinition(K, vector, whereClause, exact);
+            var ids = new List<string>();
+            long retrievedDocs = 0;
+            double ru = 0;
+
+            FeedIterator<IdWithSimilarityScore> iterator =
+                this.CosmosContainerForQuery.GetItemQueryIterator<IdWithSimilarityScore>(
+                    queryDefinition, requestOptions: new QueryRequestOptions { MaxConcurrency = this.MaxPhysicalPartitionCount });
+            while (iterator.HasMoreResults)
+            {
+                var response = await iterator.ReadNextAsync();
+                ru += response.RequestCharge;
+                foreach (var item in response)
+                {
+                    ids.Add(item.Id);
+                }
+                var metrics = response.Diagnostics.GetQueryMetrics();
+                if (metrics != null)
+                {
+                    foreach (var partitionMetrics in metrics.PartitionedMetrics)
+                    {
+                        retrievedDocs += partitionMetrics.ServerSideMetrics.RetrievedDocumentCount;
+                    }
+                }
+            }
+            return (ids, retrievedDocs, ru);
+        }
+
+        /// <summary>
+        /// Waits for the asynchronous DiskANN graph build ("lazy catch-up") to complete by probing
+        /// the data plane: it repeatedly issues the index-based (approximate) vector query and watches
+        /// the retrieved-document count. While the graph is still building, the engine falls back to a
+        /// full scan (retrieves ~all vectors); once the graph is ready the approximate search retrieves
+        /// far fewer documents. Returns the elapsed time in milliseconds when the graph engages, or the
+        /// elapsed time so far if the timeout is hit (with a warning).
+        /// </summary>
+        private async Task<double> WaitForDiskANNGraphBuildAsync(
+            string dataPath, int ingestedVectors, TimeSpan pollInterval, TimeSpan timeout)
+        {
+            const int probeK = 10;
+            T[]? probeVector = null;
+            string probeWhere = string.Empty;
+            await foreach ((int vectorId, T[] vector, string whereClause) in
+                JsonDocumentFactory<T>.GetQueryAsync(dataPath, 0 /* startVectorId */, 1 /* single */, this.IsFilterSearch))
+            {
+                probeVector = vector;
+                probeWhere = whereClause;
+                break;
+            }
+            if (probeVector == null)
+            {
+                Console.WriteLine("[CATCHUP] No probe query vector available; skipping graph-build wait.");
+                return -1;
+            }
+
+            // The graph is considered "engaged" once the approximate search retrieves fewer than half
+            // the ingested vectors (in practice it drops to ~probeK * searchListSize, far below this).
+            long engageThreshold = Math.Max(1L, ingestedVectors / 2L);
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            while (true)
+            {
+                (_, long retrievedDocs, double ru) = await RunSingleQueryWithMetrics(probeK, probeVector, probeWhere, exact: false);
+                Console.WriteLine($"[CATCHUP] probe approx retrievedDocs={retrievedDocs}, RU={ru:F2}, elapsed={stopwatch.Elapsed.TotalSeconds:F0}s (engage if < {engageThreshold})");
+
+                if (retrievedDocs > 0 && retrievedDocs < engageThreshold)
+                {
+                    stopwatch.Stop();
+                    Console.WriteLine($"[CATCHUP] DiskANN graph engaged after {stopwatch.Elapsed.TotalSeconds:F1}s.");
+                    return stopwatch.Elapsed.TotalMilliseconds;
+                }
+                if (stopwatch.Elapsed >= timeout)
+                {
+                    stopwatch.Stop();
+                    Console.WriteLine($"[CATCHUP] WARNING: DiskANN graph did not engage within {timeout.TotalMinutes:F0} min (still retrieving {retrievedDocs}).");
+                    return stopwatch.Elapsed.TotalMilliseconds;
+                }
+                await Task.Delay(pollInterval);
+            }
         }
 
         private string GetBaseDataPath()
@@ -415,6 +562,35 @@ namespace VectorIndexScenarioSuite
 
         protected async Task RunScenario()
         {
+            // Read back the effective indexing policy so we can detect whether the backend honored the
+            // requested quantizerType or silently coerced it (e.g. spherical -> product when the account
+            // does not have the spherical-quantizer preview enabled). A coerced run would make a
+            // spherical-vs-product comparison meaningless, so we surface the effective value explicitly.
+            try
+            {
+                string requestedQuantizer = this.Configurations["AppSettings:scenario:quantizerType"] ?? "";
+                var containerResponse = await this.CosmosContainerForIngestion.ReadContainerAsync();
+                var vectorIndexes = containerResponse.Resource?.IndexingPolicy?.VectorIndexes;
+                if (vectorIndexes != null && vectorIndexes.Count > 0)
+                {
+                    this.effectiveQuantizerType = vectorIndexes[0].QuantizerType.ToString();
+                    foreach (var vi in vectorIndexes)
+                    {
+                        Console.WriteLine($"[QUANTIZER-CHECK] path={vi.Path} indexType={vi.Type} effectiveQuantizer={vi.QuantizerType} (requested={requestedQuantizer})");
+                    }
+                    if (!string.IsNullOrEmpty(requestedQuantizer) &&
+                        !string.Equals(this.effectiveQuantizerType, requestedQuantizer, StringComparison.OrdinalIgnoreCase))
+                    {
+                        Console.WriteLine($"[QUANTIZER-CHECK] WARNING: requested quantizerType '{requestedQuantizer}' was coerced to '{this.effectiveQuantizerType}' by the backend. " +
+                            "The account may not have this quantizer enabled; comparison results for this run are NOT valid for the requested quantizer.");
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[QUANTIZER-CHECK] Could not read back effective quantizer type: {ex.Message}");
+            }
+
             bool onlyIngestFailedIds = Convert.ToBoolean(this.Configurations["AppSettings:onlyIngestFailedIds"]);
             if (onlyIngestFailedIds)
             {
@@ -434,13 +610,39 @@ namespace VectorIndexScenarioSuite
                     int startVectorId = Convert.ToInt32(this.Configurations["AppSettings:scenario:startVectorId"]);
                     int endVectorId = Convert.ToInt32(this.Configurations["AppSettings:scenario:endVectorId"]);
                     int totalVectors = ((endVectorId == 0 || endVectorId < startVectorId) ? sliceCount : endVectorId) - startVectorId;
+
+                    var ingestStopwatch = System.Diagnostics.Stopwatch.StartNew();
                     await PerformIngestion(IngestionOperationType.Insert, null /* startTagId */, startVectorId /* startVectorId */, totalVectors);
+                    ingestStopwatch.Stop();
+                    this.ingestionDurationMs = ingestStopwatch.Elapsed.TotalMilliseconds;
+                    Console.WriteLine($"[PERF] Ingestion of {totalVectors} vectors took {this.ingestionDurationMs / 1000.0:F2}s.");
+
+                    // Measure lazy index catch-up: wait for the asynchronous DiskANN graph build to
+                    // complete, detected by probing the data plane until the approximate query stops
+                    // falling back to a full scan.
+                    Console.WriteLine("[PERF] Waiting for lazy index catch-up (async DiskANN graph build)...");
+                    int catchupTimeoutMin = 30;
+                    string? catchupTimeoutCfg = this.Configurations["AppSettings:scenario:catchupTimeoutMinutes"];
+                    if (!string.IsNullOrWhiteSpace(catchupTimeoutCfg) && int.TryParse(catchupTimeoutCfg, out int parsedTimeout) && parsedTimeout > 0)
+                    {
+                        catchupTimeoutMin = parsedTimeout;
+                    }
+                    this.indexCatchupDurationMs = await WaitForDiskANNGraphBuildAsync(
+                        GetQueryDataPath(),
+                        totalVectors,
+                        pollInterval: TimeSpan.FromSeconds(20),
+                        timeout: TimeSpan.FromMinutes(catchupTimeoutMin));
+                    Console.WriteLine($"[PERF] Lazy index catch-up took {this.indexCatchupDurationMs / 1000.0:F2}s.");
                 }
 
                 bool runQuery = Convert.ToBoolean(this.Configurations["AppSettings:scenario:runQuery"]);
 
                 if (runQuery)
                 {
+                    // Validate the vector index (DiskANN) is actually used by comparing an index-based
+                    // (approximate) query against a brute-force (exact) query on the same vector.
+                    await ValidateDiskANNUsageAsync(GetQueryDataPath());
+
                     bool performWarmup = Convert.ToBoolean(this.Configurations["AppSettings:scenario:warmup:enabled"]);
                     if (performWarmup)
                     {
@@ -455,11 +657,15 @@ namespace VectorIndexScenarioSuite
                     int numQueries = Convert.ToInt32(this.Configurations["AppSettings:scenario:numQueries"]);
                     numQueries = numQueries == 0 ? totalQueryVectors : numQueries;
 
+                    var queryStopwatch = System.Diagnostics.Stopwatch.StartNew();
                     for (int kI = 0; kI < K_VALS.Length; kI++)
                     {
                         Console.WriteLine($"Performing {numQueries} queries for Recall/RU/Latency stats for K: {K_VALS[kI]}.");
                         await PerformQuery(false /* isWarmup */, numQueries, K_VALS[kI] /*KVal*/, GetQueryDataPath());
                     }
+                    queryStopwatch.Stop();
+                    this.queryPhaseDurationMs = queryStopwatch.Elapsed.TotalMilliseconds;
+                    Console.WriteLine($"[PERF] Query phase took {this.queryPhaseDurationMs / 1000.0:F2}s.");
                 }
             }
         }
@@ -620,6 +826,7 @@ namespace VectorIndexScenarioSuite
             bool runQuery = Convert.ToBoolean(this.Configurations["AppSettings:scenario:runQuery"]);
             bool computeRecall = Convert.ToBoolean(this.Configurations["AppSettings:scenario:computeRecall"]);
 
+            var recallByK = new Dictionary<int, float>();
             if (runQuery && computeRecall)
             {
                 Console.WriteLine("Computing Recall.");
@@ -631,6 +838,7 @@ namespace VectorIndexScenarioSuite
                 {
                     int kVal = K_VALS[kI];
                     float recall = groundTruthValidator.ComputeRecall(kVal, this.queryRecallResults[kVal]);
+                    recallByK[kVal] = recall;
 
                     Console.WriteLine($"Recall for K = {kVal} is {recall}.");
                 }
@@ -642,6 +850,67 @@ namespace VectorIndexScenarioSuite
                 bool runIngestion = Convert.ToBoolean(this.Configurations["AppSettings:scenario:runIngestion"]);
                 ComputeLatencyAndRUStats(runIngestion, runQuery);
             }
+
+            EmitResultJson(recallByK);
+        }
+
+        /// <summary>
+        /// Emits a single machine-readable summary line (prefixed RESULT_JSON:) so an external
+        /// orchestrator can aggregate spherical-vs-product comparison results across runs.
+        /// </summary>
+        private void EmitResultJson(Dictionary<int, float> recallByK)
+        {
+            string quantizerType = this.Configurations["AppSettings:scenario:quantizerType"] ?? "";
+            string datasetLabel = this.Configurations["AppSettings:scenario:datasetLabel"] ?? "";
+            string containerId = this.Configurations["AppSettings:cosmosContainerId"] ?? "";
+            int endVectorId = Convert.ToInt32(this.Configurations["AppSettings:scenario:endVectorId"]);
+            int sliceCount = Convert.ToInt32(this.Configurations["AppSettings:scenario:sliceCount"]);
+            int startVectorId = Convert.ToInt32(this.Configurations["AppSettings:scenario:startVectorId"]);
+            int ingestedVectors = ((endVectorId == 0 || endVectorId < startVectorId) ? sliceCount : endVectorId) - startVectorId;
+
+            var recallParts = new List<string>();
+            foreach (var kv in recallByK)
+            {
+                recallParts.Add($"\"{kv.Key}\":{kv.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
+            }
+
+            double avgClientLatency = 0, avgRU = 0;
+            double avgServerLatency = 0, p50ServerLatency = 0, p99ServerLatency = 0;
+            if (K_VALS.Length > 0 && this.queryMetrics.ContainsKey(K_VALS[0]))
+            {
+                avgClientLatency = this.queryMetrics[K_VALS[0]].GetClientLatencyStatistics().Avg;
+                avgRU = this.queryMetrics[K_VALS[0]].GetRequestUnitStatistics().Avg;
+                var serverStats = this.queryMetrics[K_VALS[0]].GetServerLatencyStatistics();
+                avgServerLatency = serverStats.Avg;
+                p50ServerLatency = serverStats.P50;
+                p99ServerLatency = serverStats.P99;
+            }
+
+            System.Func<double, string> f = v => v.ToString("F4", System.Globalization.CultureInfo.InvariantCulture);
+            string json = "{" +
+                $"\"datasetLabel\":\"{datasetLabel}\"," +
+                $"\"quantizerType\":\"{quantizerType}\"," +
+                $"\"effectiveQuantizerType\":\"{this.effectiveQuantizerType}\"," +
+                $"\"container\":\"{containerId}\"," +
+                $"\"ingestedVectors\":{ingestedVectors}," +
+                $"\"ingestionDurationMs\":{f(this.ingestionDurationMs)}," +
+                $"\"indexCatchupDurationMs\":{f(this.indexCatchupDurationMs)}," +
+                $"\"queryPhaseDurationMs\":{f(this.queryPhaseDurationMs)}," +
+                $"\"avgQueryClientLatencyMs\":{f(avgClientLatency)}," +
+                $"\"avgQueryServerLatencyMs\":{f(avgServerLatency)}," +
+                $"\"p50QueryServerLatencyMs\":{f(p50ServerLatency)}," +
+                $"\"p99QueryServerLatencyMs\":{f(p99ServerLatency)}," +
+                $"\"avgQueryRU\":{f(avgRU)}," +
+                $"\"recall\":{{{string.Join(",", recallParts)}}}," +
+                $"\"diskAnnValidationRan\":{this.diskAnnValidationRan.ToString().ToLowerInvariant()}," +
+                $"\"diskAnnUsed\":{this.diskAnnUsed.ToString().ToLowerInvariant()}," +
+                $"\"diskAnnApproxRetrievedDocs\":{this.diskAnnApproxRetrievedDocs}," +
+                $"\"diskAnnExactRetrievedDocs\":{this.diskAnnExactRetrievedDocs}," +
+                $"\"diskAnnApproxRU\":{f(this.diskAnnApproxRU)}," +
+                $"\"diskAnnExactRU\":{f(this.diskAnnExactRU)}," +
+                $"\"diskAnnApproxVsExactOverlapPct\":{f(this.diskAnnApproxVsExactOverlap)}" +
+                "}";
+            Console.WriteLine("RESULT_JSON: " + json);
         }
     }
 }

--- a/src/Scenario.cs
+++ b/src/Scenario.cs
@@ -41,6 +41,7 @@ namespace VectorIndexScenarioSuite
         public const int COSMOSDB_MAX_BATCH_SIZE = 100;
 
         /* Known Slices */
+        protected const int FIVE_THOUSAND = 5000;
         protected const int TEN_THOUSAND = 10000;
         protected const int HUNDRED_THOUSAND = 100000;
         protected const int ONE_MILLION =  1000000;
@@ -144,7 +145,82 @@ namespace VectorIndexScenarioSuite
             {
                 throughput = final_RUValue; // override the throughput value from the config file
             }
-            await this.CosmosContainerForIngestion.ReplaceThroughputAsync(throughput);
+            try
+            {
+                await this.CosmosContainerForIngestion.ReplaceThroughputAsync(throughput);
+            }
+            catch (Exception ex)
+            {
+                // Throughput management may be unavailable when using AAD auth without control-plane
+                // permissions (or on pre-provisioned containers). Don't let this crash the run.
+                Console.WriteLine($"Warning: could not replace throughput ({throughput} RU/s): {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Polls the container's index transformation progress until the index (including the
+        /// DiskANN vector index) is fully built, i.e. the "lazy catch-up" completes.
+        /// Returns the elapsed time in milliseconds. Returns -1 if the progress header is
+        /// unavailable, or the elapsed time so far if the timeout is hit.
+        /// </summary>
+        protected async Task<double> WaitForIndexTransformationAsync(
+            TimeSpan pollInterval, TimeSpan timeout)
+        {
+            const string ProgressHeader = "x-ms-documentdb-collection-index-transformation-progress";
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            int lastProgress = -1;
+            bool headerSeen = false;
+
+            while (true)
+            {
+                int progress = -1;
+                try
+                {
+                    ContainerResponse response = await this.CosmosContainerForIngestion.ReadContainerAsync(
+                        requestOptions: new ContainerRequestOptions { PopulateQuotaInfo = true });
+                    string? raw = response.Headers[ProgressHeader];
+                    if (!string.IsNullOrEmpty(raw) && int.TryParse(raw, out int parsed))
+                    {
+                        progress = parsed;
+                        headerSeen = true;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Warning: could not read index transformation progress: {ex.Message}");
+                }
+
+                if (progress != lastProgress)
+                {
+                    Console.WriteLine($"Index transformation progress: {progress}% (elapsed {stopwatch.Elapsed.TotalSeconds:F1}s)");
+                    lastProgress = progress;
+                }
+
+                // progress == 100 => fully built. If the header is never returned (e.g. progress is
+                // reported as -1 meaning "already up to date"), treat a non-in-progress state as done.
+                if (progress >= 100)
+                {
+                    stopwatch.Stop();
+                    return stopwatch.Elapsed.TotalMilliseconds;
+                }
+
+                if (stopwatch.Elapsed >= timeout)
+                {
+                    Console.WriteLine($"Warning: index transformation did not reach 100% within {timeout.TotalSeconds}s (last {lastProgress}%).");
+                    stopwatch.Stop();
+                    return stopwatch.Elapsed.TotalMilliseconds;
+                }
+
+                await Task.Delay(pollInterval);
+
+                if (!headerSeen && stopwatch.Elapsed > TimeSpan.FromSeconds(30))
+                {
+                    // Header never surfaced; nothing to wait on.
+                    Console.WriteLine("Index transformation progress header unavailable; skipping catch-up wait.");
+                    stopwatch.Stop();
+                    return -1;
+                }
+            }
         }
 
         protected async Task LogErrorToFile(string filePath, string message)

--- a/src/WikiCohereEnglishEmbeddingOnlyScenario.cs
+++ b/src/WikiCohereEnglishEmbeddingOnlyScenario.cs
@@ -31,6 +31,7 @@ namespace VectorIndexScenarioSuite
             int sliceCount = Convert.ToInt32(configurations["AppSettings:scenario:sliceCount"]);
             switch (sliceCount)
             {
+                case FIVE_THOUSAND:
                 case TEN_THOUSAND:
                 case HUNDRED_THOUSAND:
                 case ONE_MILLION:
@@ -40,7 +41,10 @@ namespace VectorIndexScenarioSuite
                 case THIRTY_FIVE_MILLION:
                     return (40000, 70000);
                 default:
-                    throw new ArgumentException("Invalid slice count.");
+                    // For arbitrary slice counts (e.g. perf comparison runs), keep a single
+                    // physical partition with modest throughput; the container RU can still be
+                    // overridden via AppSettings:cosmosContainerRUInitial / RUFinal.
+                    return (400, 10000);
             }
         }
     }


### PR DESCRIPTION
Add reusable Product and Spherical quantizer workload orchestration, index-after-ingest helpers, and portable dataset tooling while excluding generated benchmark data.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>